### PR TITLE
Enable ISR and revalidate every 60 seconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+.vercel
 
 # production
 /build
@@ -34,4 +35,3 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Next.js WordPress Starter <!-- omit in toc -->
 
-WebdevStudios fork of the [official Next.js WordPress Example](https://github.com/vercel/next.js/tree/canary/examples/cms-wordpress). Used as a starter for headless WordPress projects.
+WebDevStudios fork of the [official Next.js WordPress Example](https://github.com/vercel/next.js/tree/canary/examples/cms-wordpress). Used as a starter for headless WordPress projects.
 
 👉 https://nextjs-wordpress-starter.vercel.app
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -45,6 +45,7 @@ Index.propTypes = {
 export async function getStaticProps({preview = false}) {
   const allPosts = await getAllPostsForHome(preview)
   return {
-    props: {allPosts, preview}
+    props: {allPosts, preview},
+    revalidate: 60
   }
 }

--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -76,7 +76,8 @@ export async function getStaticProps({params, preview = false, previewData}) {
       preview,
       post: data.post,
       posts: data.posts
-    }
+    },
+    revalidate: 60
   }
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "use": "@vercel/next@canary",
+      "src": "package.json"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #14

### DESCRIPTION ###
- Enabled ISR by adding the `revalidate` key to getStaticProps();

### SCREENSHOT ###

![screenshot](https://dl.dropbox.com/s/ref51u47q71ihnn/Screen%20Shot%202020-08-28%20at%2010.51.44%20AM.png?dl=0)

### VERIFICATION STEPS ###
- Visit https://nextjs-wordpress-example-git-feature-14-isg.webdevstudios.vercel.app/
- Login and update a blog post TITLE at https://nextjs.wpengine.com/wp-admin
- Wait 60+ seconds
- Refresh on https://nextjs-wordpress-example-git-feature-14-isg.webdevstudios.vercel.app/