### PR TITLE
Modify code to compensate for WPGraphQL breaking changes

### DIFF
--- a/components/avatar.js
+++ b/components/avatar.js
@@ -2,14 +2,14 @@ import PropTypes from 'prop-types'
 
 export default function Avatar({author}) {
   const name =
-    author.firstName && author.lastName
-      ? `${author.firstName} ${author.lastName}`
-      : author.name
+    author.node.firstName && author.node.lastName
+      ? `${author.node.firstName} ${author.node.lastName}`
+      : author.node.name
 
   return (
     <div className="flex items-center">
       <img
-        src={author.avatar.url}
+        src={author.node.avatar.url}
         className="w-12 h-12 rounded-full mr-4"
         alt={name}
       />

--- a/components/cover-image.js
+++ b/components/cover-image.js
@@ -5,7 +5,7 @@ import Link from 'next/link'
 export default function CoverImage({title, coverImage, slug}) {
   const image = (
     <img
-      src={coverImage?.sourceUrl}
+      src={coverImage?.node?.sourceUrl}
       className={cn('shadow-small', {
         'hover:shadow-medium transition-shadow duration-200': slug
       })}

--- a/lib/api.js
+++ b/lib/api.js
@@ -71,14 +71,18 @@ export async function getAllPostsForHome(preview) {
             slug
             date
             featuredImage {
-              sourceUrl
+              node {
+                sourceUrl
+              }
             }
             author {
-              name
-              firstName
-              lastName
-              avatar {
-                url
+              node {
+                name
+                firstName
+                lastName
+                avatar {
+                  url
+                }
               }
             }
           }
@@ -122,10 +126,14 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
       slug
       date
       featuredImage {
-        sourceUrl
+        node {
+          sourceUrl
+        }
       }
       author {
-        ...AuthorFields
+        node {
+          ...AuthorFields
+        }
       }
       categories {
         edges {
@@ -157,7 +165,9 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
               excerpt
               content
               author {
-                ...AuthorFields
+                node {
+                  ...AuthorFields
+                }
               }
             }
           }

--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -37,7 +37,7 @@ export default function Post({post, posts, preview}) {
                 </title>
                 <meta
                   property="og:image"
-                  content={post.featuredImage?.sourceUrl}
+                  content={post.featuredImage?.node?.sourceUrl}
                 />
               </Head>
               <PostHeader


### PR DESCRIPTION
Closes #17 

### DESCRIPTION ###

After updating WPGraphQL (in #16) the build process broke. This was due to breaking changes in WPGraphQL `0.12.1` in how the `author` and `featuredImage` is shaped (a `node` object was added to both).

Thanks to @dcooney who figured this out and helped me understand it.

### SCREENSHOTS ###

#### Before the Fix

![image](https://user-images.githubusercontent.com/5194588/92033699-17b75b80-ed3a-11ea-897d-632636984dfb.png)

#### After the Fix

![image](https://user-images.githubusercontent.com/5194588/92033671-0bcb9980-ed3a-11ea-968a-c1f1529bf2df.png)

### OTHER ###
- [x] Does this issue pass all the linting?

### STEPS TO VERIFY ###
How do we test this?

Run `yarn dev` and verify the site builds properly.

### DOCUMENTATION ###
n/a
