### PR TITLE
Custom Post Type Pages

### DIFF
--- a/components/member.js
+++ b/components/member.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+
+export default function Member({member}) {
+  return (
+    <>
+      <h3 className="font-bold text-2xl leading-tight mb-2">
+        <Link as={`/members/${member.slug}`} href="/members/[slug]">
+          <a
+            className="hover:underline"
+            dangerouslySetInnerHTML={{__html: member.title}}
+          />
+        </Link>
+      </h3>
+      <p>{member.acf_team_member_title.title}</p>
+      <div className="max-w-2xl mx-auto mb-12">
+        <div dangerouslySetInnerHTML={{__html: member.content}} />
+      </div>
+    </>
+  )
+}
+
+Member.propTypes = {
+  member: PropTypes.object
+}

--- a/lib/api.js
+++ b/lib/api.js
@@ -59,6 +59,22 @@ export async function getAllPostsWithSlug() {
   return data?.posts
 }
 
+export async function getAllMembersWithSlug() {
+  const data = await fetchAPI(`
+    {
+      team_members(first: 1000, where: { status: PUBLISH }) {
+        edges {
+          node {
+            slug
+          }
+        }
+      }
+    }
+  `)
+
+  return data?.team_members
+}
+
 export async function getAllPostsForHome(preview) {
   const data = await fetchAPI(
     `

--- a/lib/api.js
+++ b/lib/api.js
@@ -101,6 +101,29 @@ export async function getAllPostsForHome(preview) {
   return data?.posts
 }
 
+export async function getAllTeamMembers() {
+  const data = await fetchAPI(
+    `
+    query AllMembers {
+      team_members(first: 20, where: { status: PUBLISH, orderby: { field: DATE, order: DESC } }) {
+        edges {
+          node {
+            acf_team_member_title {
+              title
+            }
+            content
+            slug
+            title
+          }
+        }
+      }
+    }
+  `
+  )
+
+  return data?.team_members
+}
+
 export async function getPostAndMorePosts(slug, preview, previewData) {
   const postPreview = preview && previewData?.post
   // The slug may be the id of an unpublished post

--- a/lib/api.js
+++ b/lib/api.js
@@ -249,3 +249,27 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
 
   return data
 }
+
+export async function getMember(slug) {
+  const data = await fetchAPI(
+    `
+    query MemberBySlug($id: ID!, $idType: TeamIdType!) {
+      team(id: $id, idType: $idType) {
+        acf_team_member_title {
+          title
+        }
+        content
+        slug
+        title
+      }
+    }`,
+    {
+      variables: {
+        id: slug,
+        idType: 'SLUG'
+      }
+    }
+  )
+
+  return data?.team
+}

--- a/pages/members.js
+++ b/pages/members.js
@@ -1,6 +1,6 @@
 import Container from '@/components/container'
-import Intro from '@/components/intro'
 import Layout from '@/components/layout'
+import Header from '@/components/header'
 import Head from 'next/head'
 import Link from 'next/link'
 import {CMS_NAME} from '@/lib/config'
@@ -9,32 +9,35 @@ import PropTypes from 'prop-types'
 
 export default function Members({allMembers: {edges}}) {
   return (
-    <>
-      <Layout>
-        <Head>
-          <title>Next.js Blog Example with {CMS_NAME}</title>
-        </Head>
-        <Container>
-          <Intro />
-          {edges.map(({node}, index) => {
-            return (
-              <div key={index}>
-                <h3>
-                  <Link as={`/members/${node.slug}`} href="/members/[slug]">
-                    <a
-                      className="hover:underline"
-                      dangerouslySetInnerHTML={{__html: node.title}}
-                    />
-                  </Link>
-                </h3>
+    <Layout>
+      <Head>
+        <title>Next.js Blog Example with {CMS_NAME}</title>
+      </Head>
+      <Container>
+        <Header />
+        <h3 className="text-5xl font-bold tracking-tighter leading-tight mb-12">
+          Members
+        </h3>
+        {edges.map(({node}, index) => {
+          return (
+            <div key={index}>
+              <h3 className="font-bold text-2xl leading-tight mb-2">
+                <Link as={`/members/${node.slug}`} href="/members/[slug]">
+                  <a
+                    className="hover:underline"
+                    dangerouslySetInnerHTML={{__html: node.title}}
+                  />
+                </Link>
+              </h3>
+              <p>{node.acf_team_member_title.title}</p>
+              <div className="max-w-2xl mx-auto mb-12">
                 <div dangerouslySetInnerHTML={{__html: node.content}} />
-                <p>{node.acf_team_member_title.title}</p>
               </div>
-            )
-          })}
-        </Container>
-      </Layout>
-    </>
+            </div>
+          )
+        })}
+      </Container>
+    </Layout>
   )
 }
 

--- a/pages/members.js
+++ b/pages/members.js
@@ -2,10 +2,10 @@ import Container from '@/components/container'
 import Layout from '@/components/layout'
 import Header from '@/components/header'
 import Head from 'next/head'
-import Link from 'next/link'
 import {CMS_NAME} from '@/lib/config'
 import {getAllTeamMembers} from '@/lib/api'
 import PropTypes from 'prop-types'
+import Member from '@/components/member'
 
 export default function Members({allMembers: {edges}}) {
   return (
@@ -19,22 +19,7 @@ export default function Members({allMembers: {edges}}) {
           Members
         </h3>
         {edges.map(({node}, index) => {
-          return (
-            <div key={index}>
-              <h3 className="font-bold text-2xl leading-tight mb-2">
-                <Link as={`/members/${node.slug}`} href="/members/[slug]">
-                  <a
-                    className="hover:underline"
-                    dangerouslySetInnerHTML={{__html: node.title}}
-                  />
-                </Link>
-              </h3>
-              <p>{node.acf_team_member_title.title}</p>
-              <div className="max-w-2xl mx-auto mb-12">
-                <div dangerouslySetInnerHTML={{__html: node.content}} />
-              </div>
-            </div>
-          )
+          return <Member key={index} member={node} />
         })}
       </Container>
     </Layout>

--- a/pages/members.js
+++ b/pages/members.js
@@ -1,0 +1,52 @@
+import Container from '@/components/container'
+import Intro from '@/components/intro'
+import Layout from '@/components/layout'
+import Head from 'next/head'
+import Link from 'next/link'
+import {CMS_NAME} from '@/lib/config'
+import {getAllTeamMembers} from '@/lib/api'
+import PropTypes from 'prop-types'
+
+export default function Members({allMembers: {edges}}) {
+  return (
+    <>
+      <Layout>
+        <Head>
+          <title>Next.js Blog Example with {CMS_NAME}</title>
+        </Head>
+        <Container>
+          <Intro />
+          {edges.map(({node}, index) => {
+            return (
+              <div key={index}>
+                <h3>
+                  <Link as={`/members/${node.slug}`} href="/members/[slug]">
+                    <a
+                      className="hover:underline"
+                      dangerouslySetInnerHTML={{__html: node.title}}
+                    />
+                  </Link>
+                </h3>
+                <div dangerouslySetInnerHTML={{__html: node.content}} />
+                <p>{node.acf_team_member_title.title}</p>
+              </div>
+            )
+          })}
+        </Container>
+      </Layout>
+    </>
+  )
+}
+
+Members.propTypes = {
+  allMembers: PropTypes.object
+}
+
+export async function getStaticProps() {
+  const allMembers = await getAllTeamMembers()
+
+  return {
+    props: {allMembers},
+    revalidate: 60
+  }
+}

--- a/pages/members/[slug].js
+++ b/pages/members/[slug].js
@@ -32,6 +32,9 @@ export default function Member({member}) {
                 </title>
               </Head>
               <PostTitle>{member.title}</PostTitle>
+              <h2 className="text-3xl font-medium">
+                {member.acf_team_member_title.title}
+              </h2>
               <PostBody content={member.content} />
             </article>
           </>

--- a/pages/members/[slug].js
+++ b/pages/members/[slug].js
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types'
+import {useRouter} from 'next/router'
+import ErrorPage from 'next/error'
+import Container from '@/components/container'
+import PostBody from '@/components/post-body'
+import Header from '@/components/header'
+import Layout from '@/components/layout'
+import {getAllMembersWithSlug, getMember} from '@/lib/api'
+import PostTitle from '@/components/post-title'
+import Head from 'next/head'
+import {CMS_NAME} from '@/lib/config'
+
+export default function Member({member}) {
+  const router = useRouter()
+
+  if (!router.isFallback && !member?.slug) {
+    return <ErrorPage statusCode={404} />
+  }
+
+  return (
+    <Layout>
+      <Container>
+        <Header />
+        {router.isFallback ? (
+          <PostTitle>Loading…</PostTitle>
+        ) : (
+          <>
+            <article>
+              <Head>
+                <title>
+                  {member.title} | Next.js Blog Example with {CMS_NAME}
+                </title>
+              </Head>
+              <PostTitle>{member.title}</PostTitle>
+              <PostBody content={member.content} />
+            </article>
+          </>
+        )}
+      </Container>
+    </Layout>
+  )
+}
+
+Member.propTypes = {
+  member: PropTypes.object
+}
+
+export async function getStaticProps({params}) {
+  const data = await getMember(params.slug)
+
+  return {
+    props: {
+      member: data
+    },
+    revalidate: 60
+  }
+}
+
+export async function getStaticPaths() {
+  const allMembers = await getAllMembersWithSlug()
+
+  return {
+    paths: allMembers.edges.map(({node}) => `/members/${node.slug}`) || [],
+    fallback: true
+  }
+}


### PR DESCRIPTION
Closes #7 

### DESCRIPTION ###
This PR adds custom post type "Team" pages to the Next.js starter.

### SCREENSHOTS ###

Team Page

![screenshot](https://i.imgur.com/6yyZylS.jpg)

Single Team Member Page

![screenshot](https://i.imgur.com/sQbn4bJ.jpg)

### OTHER ###
- [ ] Is this issue accessible? (Section 508/WCAG 2.1AA)
- [x] Does this issue pass all the linting?
- [ ] Does this pass CBT?

### STEPS TO VERIFY ###
Run `yarn install && yarn dev` in the terminal and browse to http://localhost:3000/members
