### PR TITLE
Custom Fields

### DIFF
--- a/components/custom-fields.js
+++ b/components/custom-fields.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types'
+
+export default function CustomFields({customFields}) {
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h3 className="mt-8 text-lg font-bold">What I&apos;m Into</h3>
+      {customFields.book && <p className="mt-3">Book: {customFields.book}</p>}
+      {customFields.music && (
+        <p className="mt-3">Music: {customFields.music}</p>
+      )}
+      {customFields.television && (
+        <p className="mt-3">Television: {customFields.television}</p>
+      )}
+    </div>
+  )
+}
+
+CustomFields.propTypes = {
+  customFields: PropTypes.object
+}

--- a/lib/api.js
+++ b/lib/api.js
@@ -149,6 +149,11 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
           }
         }
       }
+      acf_whatiminto {
+        book
+        music
+        television
+      }
     }
     query PostBySlug($id: ID!, $idType: PostIdType!) {
       post(id: $id, idType: $idType) {
@@ -168,6 +173,11 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
                 node {
                   ...AuthorFields
                 }
+              }
+              acf_whatiminto {
+                book
+                music
+                television
               }
             }
           }

--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -13,6 +13,7 @@ import PostTitle from '@/components/post-title'
 import Head from 'next/head'
 import {CMS_NAME} from '@/lib/config'
 import Tags from '@/components/tags'
+import CustomFields from '@/components/custom-fields'
 
 export default function Post({post, posts, preview}) {
   const router = useRouter()
@@ -48,6 +49,9 @@ export default function Post({post, posts, preview}) {
                 categories={post.categories}
               />
               <PostBody content={post.content} />
+              <div>
+                <CustomFields customFields={post.acf_whatiminto} />
+              </div>
               <footer>
                 {post.tags.edges.length > 0 && <Tags tags={post.tags} />}
               </footer>


### PR DESCRIPTION
Closes #5

### DESCRIPTION ###
This PR adds the custom fields of the post to the single post page query and displays them on the frontend.

### SCREENSHOTS ###
![screenshot](https://i.imgur.com/NU8CC0S.jpg)

### OTHER ###
- [ ] Is this issue accessible? (Section 508/WCAG 2.1AA)
- [x] Does this issue pass all the linting?
- [ ] Does this pass CBT?

### STEPS TO VERIFY ###
Run `yarn install && yarn dev` on the terminal and visit a single post page on the local website.
