### PR TITLE
Feature/45 expand queries

### DIFF
--- a/api/wordpress/gravityForms/fieldProps.js
+++ b/api/wordpress/gravityForms/fieldProps.js
@@ -1,0 +1,20 @@
+// Define Gravity Form global field props.
+export const globalFieldProps = `
+  id
+  adminLabel
+  adminOnly
+  allowsPrepopulate
+  conditionalLogic {
+    rules {
+      fieldId
+      operator
+      value
+    }
+    actionType
+    logicType
+  }
+  cssClassList
+  label
+  type
+  visibility
+`

--- a/api/wordpress/gravityForms/fieldProps.js
+++ b/api/wordpress/gravityForms/fieldProps.js
@@ -52,7 +52,7 @@ export const fieldProps = {
   ChainedSelectField: `
     chainedSelectsAlignment
     chainedSelectsHideInactive
-    choices {
+    chainedSelectChoices: choices {
       choices {
         choices {
           choices {
@@ -94,7 +94,7 @@ export const fieldProps = {
     size
   `,
   CheckboxField: `
-    choices {
+    checkboxChoices: choices {
       isSelected
       text
       value
@@ -156,7 +156,7 @@ export const fieldProps = {
   ListField: `
     addIconUrl
     allowsPrepopulate
-    choices {
+    listChoices: choices {
       text
       value
     }
@@ -171,7 +171,7 @@ export const fieldProps = {
     pageNumber
   `,
   MultiSelectField: `
-    choices {
+    multiSelectChoices: choices {
       isSelected
       text
       value
@@ -249,7 +249,7 @@ export const fieldProps = {
   `,
   PasswordField: `
     allowsPrepopulate
-    choices
+    passwordChoices: choices
     description
     errorMessage
     inputs {
@@ -277,7 +277,7 @@ export const fieldProps = {
   `,
   PostCategoryField: `
     allowsPrepopulate
-    choices {
+    postCategoryChoices: choices {
       isSelected
       text
       value
@@ -355,7 +355,7 @@ export const fieldProps = {
   `,
   RadioField: `
     allowsPrepopulate
-    choices {
+    radioChoices: choices {
       isSelected
       text
       value
@@ -388,7 +388,7 @@ export const fieldProps = {
   `,
   SelectField: `
     allowsPrepopulate
-    choices {
+    selectChoices: choices {
       isSelected
       text
       value

--- a/api/wordpress/gravityForms/fieldProps.js
+++ b/api/wordpress/gravityForms/fieldProps.js
@@ -18,3 +18,434 @@ export const globalFieldProps = `
   type
   visibility
 `
+
+// Define Gravity Form field names and unique props.
+export const fieldProps = {
+  AddressField: `
+    addressType
+    defaultCountry
+    defaultProvince
+    defaultState
+    description
+    errorMessage
+    inputName
+    inputs {
+      id
+      isHidden
+      key
+      label
+      name
+    }
+    isRequired
+    labelPlacement
+    size
+    subLabelPlacement
+  `,
+  CaptchaField: `
+    captchaTheme
+    captchaType
+    errorMessage
+    simpleCaptchaBackgroundColor
+    simpleCaptchaFontColor
+    simpleCaptchaSize
+  `,
+  ChainedSelectField: `
+    chainedSelectsAlignment
+    chainedSelectsHideInactive
+    choices {
+      choices {
+        choices {
+          choices {
+            isSelected
+            text
+            value
+          }
+          isSelected
+          text
+          value
+        }
+        isSelected
+        text
+        value
+      }
+      isSelected
+      text
+      value
+    }
+    conditionalLogic {
+      actionType
+      logicType
+      rules {
+        fieldId
+        operator
+        value
+      }
+    }
+    description
+    errorMessage
+    inputs {
+      id
+      isHidden
+      key
+      label
+      name
+    }
+    isRequired
+    size
+  `,
+  CheckboxField: `
+    choices {
+      isSelected
+      text
+      value
+    }
+    description
+    enableChoiceValue
+    enableSelectAll
+    errorMessage
+    inputName
+    inputs {
+      id
+      label
+      name
+    }
+    isRequired
+    size
+  `,
+  DateField: `
+    calendarIconType
+    calendarIconUrl
+    dateFormat
+    defaultValue
+    description
+    errorMessage
+    inputName
+    isRequired
+    noDuplicates
+    placeholder
+    size
+  `,
+  EmailField: `
+    defaultValue
+    description
+    errorMessage
+    inputName
+    isRequired
+    noDuplicates
+    placeholder
+    size
+  `,
+  FileUploadField: `
+    description
+    errorMessage
+    inputName
+    isRequired
+    size
+  `,
+  HiddenField: `
+    defaultValue
+    inputName
+    isRequired
+    noDuplicates
+    size
+  `,
+  HtmlField: `
+    content
+    inputName
+  `,
+  ListField: `
+    addIconUrl
+    allowsPrepopulate
+    choices {
+      text
+      value
+    }
+    deleteIconUrl
+    description
+    enableColumns
+    errorMessage
+    inputName
+    isRequired
+    labelPlacement
+    maxRows
+    pageNumber
+  `,
+  MultiSelectField: `
+    choices {
+      isSelected
+      text
+      value
+    }
+    description
+    enableChoiceValue
+    enableEnhancedUI
+    errorMessage
+    inputName
+    isRequired
+    size
+  `,
+  NameField: `
+    allowsPrepopulate
+    description
+    errorMessage
+    inputName
+    inputs {
+      id
+      isHidden
+      key
+      label
+      name
+    }
+    isRequired
+    nameFormat
+    size
+  `,
+  NumberField: `
+    allowsPrepopulate
+    defaultValue
+    description
+    errorMessage
+    inputName
+    isRequired
+    noDuplicates
+    numberFormat
+    placeholder
+    rangeMax
+    rangeMin
+    size
+  `,
+  PageField: `
+    allowsPrepopulate
+    displayOnly
+    nextButton {
+      conditionalLogic {
+        actionType
+        logicType
+        rules {
+          fieldId
+          operator
+          value
+        }
+      }
+      imageUrl
+      text
+      type
+    }
+    pageNumber
+    previousButton {
+      conditionalLogic {
+        actionType
+        logicType
+        rules {
+          fieldId
+          operator
+          value
+        }
+      }
+      imageUrl
+      text
+      type
+    }
+  `,
+  PasswordField: `
+    allowsPrepopulate
+    choices
+    description
+    errorMessage
+    inputs {
+      customLabel
+      id
+      label
+      placeholder
+    }
+    isRequired
+    minPasswordStrength
+    passwordStrengthEnabled
+    placeholder
+  `,
+  PhoneField: `
+    allowsPrepopulate
+    defaultValue
+    description
+    errorMessage
+    inputName
+    isRequired
+    noDuplicates
+    phoneFormat
+    placeholder
+    size
+  `,
+  PostCategoryField: `
+    allowsPrepopulate
+    choices {
+      isSelected
+      text
+      value
+    }
+    description
+    displayAllCategories
+    errorMessage
+    inputName
+    isRequired
+    size
+  `,
+  PostContentField: `
+    allowsPrepopulate
+    defaultValue
+    description
+    errorMessage
+    inputName
+    isRequired
+    placeholder
+    size
+  `,
+  PostCustomField: `
+    allowsPrepopulate
+    defaultValue
+    description
+    errorMessage
+    inputName
+    inputType
+    isRequired
+    noDuplicates
+    placeholder
+    postCustomFieldName
+    size
+  `,
+  PostExcerptField: `
+    allowsPrepopulate
+    defaultValue
+    description
+    errorMessage
+    inputName
+    isRequired
+    placeholder
+    size
+  `,
+  PostImageField: `
+    allowsPrepopulate
+    description
+    displayCaption
+    displayDescription
+    displayTitle
+    errorMessage
+    inputName
+    isRequired
+    size
+  `,
+  PostTagsField: `
+    allowsPrepopulate
+    defaultValue
+    description
+    errorMessage
+    inputName
+    isRequired
+    placeholder
+    size
+  `,
+  PostTitleField: `
+    allowsPrepopulate
+    defaultValue
+    description
+    errorMessage
+    inputName
+    isRequired
+    placeholder
+    size
+  `,
+  RadioField: `
+    allowsPrepopulate
+    choices {
+      isSelected
+      text
+      value
+    }
+    description
+    enableChoiceValue
+    enableOtherChoice
+    errorMessage
+    inputName
+    isRequired
+    noDuplicates
+    size
+  `,
+  SectionField: `
+    allowsPrepopulate
+    description
+  `,
+  SignatureField: `
+    allowsPrepopulate
+    backgroundColor
+    borderColor
+    borderStyle
+    borderWidth
+    boxWidth
+    description
+    errorMessage
+    isRequired
+    penColor
+    penSize
+  `,
+  SelectField: `
+    allowsPrepopulate
+    choices {
+      isSelected
+      text
+      value
+    }
+    description
+    enableChoiceValue
+    enableEnhancedUI
+    errorMessage
+    inputName
+    isRequired
+    noDuplicates
+    placeholder
+    size
+  `,
+  TextAreaField: `
+    allowsPrepopulate
+    defaultValue
+    description
+    errorMessage
+    inputName
+    isRequired
+    maxLength
+    noDuplicates
+    placeholder
+    size
+  `,
+  TextField: `
+    allowsPrepopulate
+    defaultValue
+    description
+    enablePasswordInput
+    errorMessage
+    inputName
+    isRequired
+    maxLength
+    noDuplicates
+    placeholder
+    size
+  `,
+  TimeField: `
+    allowsPrepopulate
+    description
+    errorMessage
+    inputName
+    isRequired
+    noDuplicates
+    size
+  `,
+  WebsiteField: `
+    allowsPrepopulate
+    defaultValue
+    description
+    errorMessage
+    inputName
+    isRequired
+    noDuplicates
+    placeholder
+    size
+  `
+}

--- a/api/wordpress/gravityForms/queryFormById.js
+++ b/api/wordpress/gravityForms/queryFormById.js
@@ -1,4 +1,5 @@
-const {gql} = require('@apollo/client')
+import {fieldProps, globalFieldProps} from './fieldProps'
+import {gql} from '@apollo/client'
 
 /**
  * Partial: retrieve basic data on all form fields.
@@ -6,49 +7,14 @@ const {gql} = require('@apollo/client')
  * @return {string} Form fields query partial.
  */
 function getFormFieldsPartial() {
-  const fields = [
-    'AddressField',
-    'CaptchaField',
-    'ChainedSelectField',
-    'CheckboxField',
-    'DateField',
-    'EmailField',
-    'FileUploadField',
-    'HiddenField',
-    'HtmlField',
-    'ListField',
-    'MultiSelectField',
-    'NameField',
-    'NumberField',
-    'PageField',
-    'PasswordField',
-    'PhoneField',
-    'PostCategoryField',
-    'PostContentField',
-    'PostCustomField',
-    'PostExcerptField',
-    'PostImageField',
-    'PostTagsField',
-    'PostTitleField',
-    'RadioField',
-    'SectionField',
-    'SignatureField',
-    'SelectField',
-    'TextAreaField',
-    'TextField',
-    'TimeField',
-    'WebsiteField'
-  ]
-
   return (
-    fields
+    Object.keys(fieldProps)
       // Build individual query partials by field type.
       .map(
         (field) => `
           ... on ${field} {
-            type
-            label
-            cssClass
+            ${globalFieldProps}
+            ${fieldProps[field]}
           }
         `
       )


### PR DESCRIPTION
References #45 

### Link

Will not work on dev until dev is updated to PHP 7.4+ and WPGraphQL add-on for GraphQL is updated to `master` version.

### Description

Expands GF single form query to include all props for each field.

### Screenshot

![Screen Shot 2020-12-29 at 11 57 45 AM](https://user-images.githubusercontent.com/36422618/103307376-1555cd00-49cd-11eb-9615-ed1b83e6887e.png)

### Verification

http://localhost:3000/form-example
- All props for each field should display
