### PR TITLE
Tweak doc blocks for consistency

### DIFF
--- a/components/molecules/GravityForm/GravityForm.js
+++ b/components/molecules/GravityForm/GravityForm.js
@@ -15,8 +15,8 @@ export default function GravityForm({
   /**
    * Map field GravityForm ids and defaults to Object.
    *
-   * @param {Array} fields Array of fields.
-   * @returns {Object} default field values.
+   * @param {Array}   fields Array of fields.
+   * @return {Object} default field values.
    */
   function getFieldDefaults(fields) {
     const defaults = {}

--- a/components/molecules/GravityForm/GravityForm.js
+++ b/components/molecules/GravityForm/GravityForm.js
@@ -16,7 +16,7 @@ export default function GravityForm({
    * Map field GravityForm ids and defaults to Object.
    *
    * @param {Array}   fields Array of fields.
-   * @return {Object} default field values.
+   * @return {Object} Default field values.
    */
   function getFieldDefaults(fields) {
     const defaults = {}

--- a/functions/gravityForms/getGfFieldId.js
+++ b/functions/gravityForms/getGfFieldId.js
@@ -1,8 +1,8 @@
 /**
  * Create a field ID based on GravityForms provided ID.
  *
- * @param {integer}  fieldId number.
- * @returns {string} A unique string identifer for the field.
+ * @param {number}  fieldId GravityForm field ID.
+ * @return {string} A unique string identifer for the field.
  */
 export default function getGfFieldId(fieldId) {
   if (!fieldId || typeof fieldId !== 'number') {

--- a/functions/gravityForms/getGfFieldValidationSchema.js
+++ b/functions/gravityForms/getGfFieldValidationSchema.js
@@ -8,8 +8,8 @@ import StringSchemaFactory from '@/functions/gravityForms/yupSchema/StringSchema
  *
  * @author WebDevStudios
  * @see https://github.com/jquense/yup#api
- * @param {Object}   fieldData GravityForm field props.
- * @returns {Object} Schema validation for field.
+ * @param {Object}  fieldData GravityForm field props.
+ * @return {Object} Schema validation for field.
  */
 function getValidationSchemaByType(fieldData) {
   let schemaGetter = null
@@ -30,8 +30,8 @@ function getValidationSchemaByType(fieldData) {
  * Map props to validation schemas.
  *
  * @author WebDevStudios
- * @param {Object}   fieldData GravityForm field props.
- * @returns {Object} Schema validation for field.
+ * @param {Object}  fieldData GravityForm field props.
+ * @return {Object} Schema validation for field.
  */
 export default function getGfFieldValidationSchema(fieldData) {
   return {

--- a/functions/gravityForms/getHiddenClassName.js
+++ b/functions/gravityForms/getHiddenClassName.js
@@ -1,8 +1,8 @@
 /**
  * Determine hidden className.
  *
- * @param {string}   visibility setting of GravityForm field.
- * @returns {string} Classname selector based on visibility.
+ * @param {string}  visibility setting of GravityForm field.
+ * @return {string} Classname selector based on visibility.
  */
 export default function getGfHiddenClassName(visibility) {
   if (!visibility || typeof visibility !== 'string') {

--- a/functions/gravityForms/yupSchema/StringSchemaFactory.js
+++ b/functions/gravityForms/yupSchema/StringSchemaFactory.js
@@ -5,7 +5,7 @@ import * as Yup from 'yup'
  *
  * @author WebDevStudios
  * @see https://github.com/jquense/yup#string
- * @returns {Object} Yup validationSchema Object.
+ * @return {Object} Yup validationSchema Object.
  */
 export default class StringSchemaFactory {
   /**
@@ -26,7 +26,7 @@ export default class StringSchemaFactory {
    * Combine multiple schemas into one.
    *
    * @see https://github.com/jquense/yup#mixedconcatschema-schema-schema
-   * @returns {Object} Combined Yup validationSchema Object.
+   * @return {Object} Combined Yup validationSchema Object.
    */
   get schema() {
     return Yup.string()


### PR DESCRIPTION
### Description
Minor adjustments to some doc blocks for improve consistency as mentioned on a previous PR.

Comments:
- https://github.com/WebDevStudios/nextjs-wordpress-starter/pull/69/files/0f72bcfb120214779c5fd502735d27bb01614f9d#r554201831
- https://github.com/WebDevStudios/nextjs-wordpress-starter/pull/69/files/0f72bcfb120214779c5fd502735d27bb01614f9d#r554202794

## Updates
- Change `@returns` to `@return`
- Update `@param {integer}` to `@param {number}`
- Update description for fieldId param

## How to Test
Code review.
