### PR TITLE
Feature/gravityform demo

### DIFF
--- a/components/molecules/GravityForm/Fields/Fields.js
+++ b/components/molecules/GravityForm/Fields/Fields.js
@@ -43,6 +43,14 @@ export default function Fields({fields, setFormValidation}) {
               fieldToRender = <GfFields.Checkbox {...field.node} key={id} />
               break
 
+            case 'email':
+              fieldToRender = <GfFields.Text {...field.node} key={id} />
+              break
+
+            case 'phone':
+              fieldToRender = <GfFields.Text {...field.node} key={id} />
+              break
+
             case 'text':
               fieldToRender = <GfFields.Text {...field.node} key={id} />
               break

--- a/components/molecules/GravityForm/Fields/Fields.js
+++ b/components/molecules/GravityForm/Fields/Fields.js
@@ -3,6 +3,15 @@ import * as GfFields from '.'
 import {useEffect} from 'react'
 import getGfFieldValidationSchema from '@/functions/gravityForms/getGfFieldValidationSchema'
 
+/**
+ * Render the Fields component.
+ *
+ * @author WebDevStudios
+ * @param {object}   props                   The component attributes as props.
+ * @param {Array}    props.fields            GravityForm fields data.
+ * @param {Function} props.setFormValidation Callback function for setting formValidation state.
+ * @return {Element}                         The Fields component.
+ */
 export default function Fields({fields, setFormValidation}) {
   /**
    * Map through fields to setup form validation.

--- a/components/molecules/GravityForm/Fields/Fields.js
+++ b/components/molecules/GravityForm/Fields/Fields.js
@@ -55,6 +55,10 @@ export default function Fields({fields, setFormValidation}) {
               fieldToRender = <GfFields.Text {...field.node} key={id} />
               break
 
+            case 'website':
+              fieldToRender = <GfFields.Text {...field.node} key={id} />
+              break
+
             default:
               fieldToRender = (
                 <pre key={id}>

--- a/components/molecules/GravityForm/Fields/Text.js
+++ b/components/molecules/GravityForm/Fields/Text.js
@@ -52,6 +52,10 @@ export default function Text({
       inputType = 'tel'
     }
 
+    if (type === 'website') {
+      inputType = 'url'
+    }
+
     return inputType
   }
 

--- a/components/molecules/GravityForm/Fields/Text.js
+++ b/components/molecules/GravityForm/Fields/Text.js
@@ -3,6 +3,23 @@ import * as Input from '@/components/atoms/Inputs'
 import {getGfFieldId, getGfHiddenClassName} from '@/functions/gravityForms'
 import cn from 'classnames'
 
+/**
+ * Render the GravityForm Text component.
+ *
+ * @author WebDevStudios
+ * @param {object}  props                     GravityForm field props.
+ * @param {string}  props.className           Classname string.
+ * @param {string}  props.description         GravityForm field description.
+ * @param {boolean} props.enablePasswordInput GravityForm password enabled option.
+ * @param {string}  props.errorMessage        GravityForm error message option.
+ * @param {number}  props.id                  GravityForm unique field id.
+ * @param {boolean} props.isRequired          GravityForm isRequired field.
+ * @param {string}  props.label               GravityForm field label.
+ * @param {string}  props.size                GravityForm field size.
+ * @param {string}  props.type                GravityForm field type.
+ * @param {boolean} props.visibility          GravityForm visibility option.
+ * @return {Element}                          The Text component.
+ */
 export default function Text({
   className,
   description,

--- a/components/molecules/GravityForm/Fields/Text.js
+++ b/components/molecules/GravityForm/Fields/Text.js
@@ -35,6 +35,28 @@ export default function Text({
   const fieldId = getGfFieldId(id)
   const isHiddenClass = getGfHiddenClassName(visibility)
 
+  /**
+   * Convert type to an HTML input type.
+   *
+   * @param {string} type GravityForm field type.
+   * @return {string}     HTML input type.
+   */
+  function modifyFieldType(type) {
+    let inputType = type
+
+    if (enablePasswordInput && 'password') {
+      inputType = 'password'
+    }
+
+    if (type === 'phone') {
+      inputType = 'tel'
+    }
+
+    return inputType
+  }
+
+  const inputType = modifyFieldType(type)
+
   return (
     <div
       className={cn(className, isHiddenClass) || null}
@@ -46,7 +68,7 @@ export default function Text({
         id={fieldId}
         isRequired={isRequired}
         label={label}
-        type={(enablePasswordInput && 'password') || type}
+        type={inputType}
       />
     </div>
   )

--- a/components/molecules/GravityForm/GravityForm.js
+++ b/components/molecules/GravityForm/GravityForm.js
@@ -4,6 +4,8 @@ import Fields from './Fields'
 import * as Yup from 'yup'
 import getGfFieldId from '@/functions/gravityForms/getGfFieldId'
 import {useState} from 'react'
+import styles from './GravityForm.module.css'
+import cn from 'classnames'
 
 /**
  * Render the GravityForm component.
@@ -54,7 +56,7 @@ export default function GravityForm({
 
   return (
     <Form
-      className={cssClass}
+      className={cn(styles.gravityForm, cssClass)}
       formDefaults={fieldDefaults}
       id={formId && `gform-${formId}`}
       title={title}

--- a/components/molecules/GravityForm/GravityForm.js
+++ b/components/molecules/GravityForm/GravityForm.js
@@ -5,6 +5,17 @@ import * as Yup from 'yup'
 import getGfFieldId from '@/functions/gravityForms/getGfFieldId'
 import {useState} from 'react'
 
+/**
+ * Render the GravityForm component.
+ *
+ * @param {object} props                   The GravityForm block attributes as props.
+ * @param {object} props.formData          GravityForm form data.
+ * @param {string} props.formData.cssClass GravityForm form classname.
+ * @param {object} props.formData.fields   GravityForm form fields.
+ * @param {number} props.formData.formId   GravityForm form id.
+ * @param {string} props.formData.title    GravityForm form title.
+ * @return {Element}                       The GravityForm component.
+ */
 export default function GravityForm({
   formData: {cssClass, fields, formId, title}
 }) {
@@ -15,8 +26,8 @@ export default function GravityForm({
   /**
    * Map field GravityForm ids and defaults to Object.
    *
-   * @param {Array}   fields Array of fields.
-   * @return {Object} Default field values.
+   * @param {Array} fields Array of fields.
+   * @return {object}      Default field values.
    */
   function getFieldDefaults(fields) {
     const defaults = {}

--- a/components/molecules/GravityForm/GravityForm.module.css
+++ b/components/molecules/GravityForm/GravityForm.module.css
@@ -1,0 +1,5 @@
+.gravityForm {
+  & > div {
+    @apply mb-5;
+  }
+}

--- a/functions/gravityForms/getGfFieldValidationSchema.js
+++ b/functions/gravityForms/getGfFieldValidationSchema.js
@@ -20,6 +20,14 @@ function getValidationSchemaByType(fieldData) {
       schemaGetter = new ArraySchemaFactory(fieldData).schema
       break
 
+    case 'email':
+      schemaGetter = new StringSchemaFactory(fieldData).schema
+      break
+
+    case 'phone':
+      schemaGetter = new StringSchemaFactory(fieldData).schema
+      break
+
     case 'text':
       schemaGetter = new StringSchemaFactory(fieldData).schema
       break

--- a/functions/gravityForms/getGfFieldValidationSchema.js
+++ b/functions/gravityForms/getGfFieldValidationSchema.js
@@ -32,6 +32,10 @@ function getValidationSchemaByType(fieldData) {
       schemaGetter = new StringSchemaFactory(fieldData).schema
       break
 
+    case 'website':
+      schemaGetter = new StringSchemaFactory(fieldData).schema
+      break
+
     default:
       return
   }

--- a/functions/gravityForms/getGfFieldValidationSchema.js
+++ b/functions/gravityForms/getGfFieldValidationSchema.js
@@ -9,8 +9,8 @@ import ArraySchemaFactory from '@/functions/gravityForms/yupSchema/ArraySchemaFa
  *
  * @author WebDevStudios
  * @see https://github.com/jquense/yup#api
- * @param {Object}  fieldData GravityForm field props.
- * @return {Object} Schema validation for field.
+ * @param {object} fieldData GravityForm field props.
+ * @return {object}          Schema validation for field.
  */
 function getValidationSchemaByType(fieldData) {
   let schemaGetter = null
@@ -35,8 +35,8 @@ function getValidationSchemaByType(fieldData) {
  * Map props to validation schemas.
  *
  * @author WebDevStudios
- * @param {Object}  fieldData GravityForm field props.
- * @return {Object} Schema validation for field.
+ * @param {object} fieldData GravityForm field props.
+ * @return {object}          Schema validation for field.
  */
 export default function getGfFieldValidationSchema(fieldData) {
   return {

--- a/functions/gravityForms/yupSchema/StringSchemaFactory.js
+++ b/functions/gravityForms/yupSchema/StringSchemaFactory.js
@@ -5,7 +5,7 @@ import * as Yup from 'yup'
  *
  * @author WebDevStudios
  * @see https://github.com/jquense/yup#string
- * @return {Object} Yup validationSchema Object.
+ * @return {object} Yup validationSchema Object.
  */
 export default class StringSchemaFactory {
   /**
@@ -14,7 +14,7 @@ export default class StringSchemaFactory {
    * Note: wp-graphql-gravity-forms plugin may need to be replaced.
    *
    * @see https://github.com/harness-software/wp-graphql-gravity-forms
-   * @param {Object} fieldData from GravityForm GraphQL data Object.
+   * @param {object} fieldData from GravityForm GraphQL data Object.
    */
   constructor(fieldData) {
     this.fieldData = fieldData
@@ -26,7 +26,7 @@ export default class StringSchemaFactory {
    * Combine multiple schemas into one.
    *
    * @see https://github.com/jquense/yup#mixedconcatschema-schema-schema
-   * @return {Object} Combined Yup validationSchema Object.
+   * @return {object} Combined Yup validationSchema Object.
    */
   get schema() {
     return Yup.string()
@@ -38,7 +38,7 @@ export default class StringSchemaFactory {
    * Get Yup required field validaion.
    *
    * @see https://github.com/jquense/yup#stringrequiredmessage-string--function-schema
-   * @return {Object} Yup validationSchema Object.
+   * @return {object} Yup validationSchema Object.
    */
   getRequiredSchema() {
     if (!this.fieldData?.isRequired) {
@@ -52,7 +52,7 @@ export default class StringSchemaFactory {
    * Get Yup max line length validation.
    *
    * @see https://github.com/jquense/yup#stringmaxlimit-number--ref-message-string--function-schema
-   * @return {Object} Yup validationSchema Object.
+   * @return {object} Yup validationSchema Object.
    */
   getMaxLengthSchema() {
     if (!this.fieldData?.maxLength) {

--- a/functions/gravityForms/yupSchema/StringSchemaFactory.js
+++ b/functions/gravityForms/yupSchema/StringSchemaFactory.js
@@ -56,7 +56,7 @@ export default class StringSchemaFactory {
    * @return {object} Yup validationSchema Object.
    */
   getEmailSchema() {
-    if (!this.fieldData?.type === 'email') {
+    if (this.fieldData?.type !== 'email') {
       return
     }
 

--- a/functions/gravityForms/yupSchema/StringSchemaFactory.js
+++ b/functions/gravityForms/yupSchema/StringSchemaFactory.js
@@ -33,6 +33,7 @@ export default class StringSchemaFactory {
       .concat(this.getEmailSchema())
       .concat(this.getMaxLengthSchema())
       .concat(this.getRequiredSchema())
+      .concat(this.getUrlSchema())
   }
 
   /**
@@ -78,5 +79,19 @@ export default class StringSchemaFactory {
       this.fieldData.maxLength,
       `Must be ${this.fieldData.maxLength} characters or less`
     )
+  }
+
+  /**
+   * Get Yup required field validaion.
+   *
+   * @see https://github.com/jquense/yup#stringurlmessage-string--function-schema
+   * @return {object} Yup validationSchema Object.
+   */
+  getUrlSchema() {
+    if (this.fieldData?.type !== 'website') {
+      return
+    }
+
+    return Yup.string().url(`Must be a valid url "https://example.com".`)
   }
 }

--- a/functions/gravityForms/yupSchema/StringSchemaFactory.js
+++ b/functions/gravityForms/yupSchema/StringSchemaFactory.js
@@ -39,20 +39,6 @@ export default class StringSchemaFactory {
   /**
    * Get Yup required field validaion.
    *
-   * @see https://github.com/jquense/yup#stringrequiredmessage-string--function-schema
-   * @return {object} Yup validationSchema Object.
-   */
-  getRequiredSchema() {
-    if (!this.fieldData?.isRequired) {
-      return
-    }
-
-    return Yup.string().required('Required!')
-  }
-
-  /**
-   * Get Yup required field validaion.
-   *
    * @see https://github.com/jquense/yup#stringemailmessage-string--function-schema
    * @return {object} Yup validationSchema Object.
    */
@@ -79,6 +65,20 @@ export default class StringSchemaFactory {
       this.fieldData.maxLength,
       `Must be ${this.fieldData.maxLength} characters or less`
     )
+  }
+
+  /**
+   * Get Yup required field validaion.
+   *
+   * @see https://github.com/jquense/yup#stringrequiredmessage-string--function-schema
+   * @return {object} Yup validationSchema Object.
+   */
+  getRequiredSchema() {
+    if (!this.fieldData?.isRequired) {
+      return
+    }
+
+    return Yup.string().required('Required!')
   }
 
   /**

--- a/functions/gravityForms/yupSchema/StringSchemaFactory.js
+++ b/functions/gravityForms/yupSchema/StringSchemaFactory.js
@@ -30,6 +30,7 @@ export default class StringSchemaFactory {
    */
   get schema() {
     return Yup.string()
+      .concat(this.getEmailSchema())
       .concat(this.getMaxLengthSchema())
       .concat(this.getRequiredSchema())
   }
@@ -46,6 +47,20 @@ export default class StringSchemaFactory {
     }
 
     return Yup.string().required('Required!')
+  }
+
+  /**
+   * Get Yup required field validaion.
+   *
+   * @see https://github.com/jquense/yup#stringemailmessage-string--function-schema
+   * @return {object} Yup validationSchema Object.
+   */
+  getEmailSchema() {
+    if (!this.fieldData?.type === 'email') {
+      return
+    }
+
+    return Yup.string().email(`Must be a valid email.`)
   }
 
   /**

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -6,6 +6,14 @@ import PropTypes from 'prop-types'
 // Define route post type.
 const postType = 'page'
 
+/**
+ * Render the Page component.
+ *
+ * @author WebDevStudios
+ * @param {object} props      The component attributes as props.
+ * @param {object} props.post Post data from WordPress.
+ * @return {Element}          The Page component.
+ */
 export default function Page({post}) {
   return (
     <Layout
@@ -44,7 +52,7 @@ export default function Page({post}) {
  * Get post static paths.
  *
  * @author WebDevStudios
- * @return {Object} Object consisting of array of paths and fallback setting.
+ * @return {object} Object consisting of array of paths and fallback setting.
  */
 export async function getStaticPaths() {
   return await getPostTypeStaticPaths(postType)
@@ -53,11 +61,9 @@ export async function getStaticPaths() {
 /**
  * Get post static props.
  *
- * @param  {Object}  context             Context for current post.
- * @param  {Object}  context.params      Route parameters for current post.
- * @param  {boolean} context.preview     Whether requesting preview of post.
- * @param  {Object}  context.previewData Post preview data.
- * @return {Object}                      Post props.
+ * @param {object} context        Context for current post.
+ * @param {object} context.params Route parameters for current post.
+ * @return {object}               Post props.
  */
 export async function getStaticProps({params}) {
   return getPostTypeStaticProps(params, postType)

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -3,6 +3,10 @@ import getPostTypeStaticProps from '@/api/wordpress/_global/getPostTypeStaticPro
 import Layout from '@/components/common/Layout'
 import PropTypes from 'prop-types'
 
+// TODO Remove BlockGravityForm once block support is added.
+// TODO Remove slug based BlockGravityForm from page render.
+import BlockGravityForm from '@/components/blocks/BlockGravityForm'
+
 // Define route post type.
 const postType = 'page'
 
@@ -43,6 +47,7 @@ export default function Page({post}) {
             />
           </article>
         </section>
+        {post.slug === 'form-demo' && <BlockGravityForm {...post?.blocks[0]} />}
       </div>
     </Layout>
   )


### PR DESCRIPTION
Closes "Greg want's a form demo" (does not have an open issue)

### Description

This PR adds the following

- Hardcoded form demo slug that renders to the first field as BlockGravityForm. Note: This is a temporary feature and TODOs are added around removing it.
- Add field type support for `email` and `phone` fields from GravityForms. These fields utilize the `Text` component they just needed to be added as such.
- Add email validation field.
- Fix doc blocks along the way.
- Refactor the `Text` field input type prop into a function. There were too many conditionals and this needed to be isolated.

Note: Phone field validation is not setup at this time and is opened in a new issue https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/92

### Screenshot
**Example of the contact form**
<img width="1533" alt="Screen Shot 2021-01-13 at 1 26 45 PM" src="https://user-images.githubusercontent.com/25035900/104493414-019c9000-55a3-11eb-9188-9410f30d9eaf.png">

**Example of required text field**
<img width="241" alt="Screen Shot 2021-01-13 at 1 27 48 PM" src="https://user-images.githubusercontent.com/25035900/104493565-33155b80-55a3-11eb-92f1-8e7191e0c57e.png">

**Example of required email field with incorrect email**
<img width="268" alt="Screen Shot 2021-01-13 at 1 27 55 PM" src="https://user-images.githubusercontent.com/25035900/104493578-36104c00-55a3-11eb-89fe-72f6710cd8ca.png">

**Example of required website field with incorrect url**
<img width="335" alt="Screen Shot 2021-01-13 at 1 51 08 PM" src="https://user-images.githubusercontent.com/25035900/104496018-6e655980-55a6-11eb-9b05-1d5425a980af.png">

**Example form submission**
Forms submissions are not yet wired up at this time.
<img width="490" alt="Screen Shot 2021-01-13 at 1 50 13 PM" src="https://user-images.githubusercontent.com/25035900/104496062-7a511b80-55a6-11eb-948c-c3f374766182.png">

**Form Data on submission**
Each field is saved according to it's unique GravityForm id value. This format will likely change later.
<img width="444" alt="Screen Shot 2021-01-13 at 1 52 14 PM" src="https://user-images.githubusercontent.com/25035900/104496166-9d7bcb00-55a6-11eb-8551-4ad3d3e3c164.png">


### Verification

How will a stakeholder test this?

**Note: You'll need to test this on your local and try this feature out. There are some issues with staging not displaying the correct form data. See the data response error https://nextjs-wordpress-starter-bv8nu8um6.vercel.app/form-demo.**

1. Make sure your local is up to date, you should have a page called `Form Demo`.
2. Visit `http://localhost:3000/form-demo` on your local. (this is the url that the block will render on)
3. Play around with the form.