### PR TITLE
Feature/45 gravity form select field

### DIFF
--- a/components/atoms/Inputs/Checkbox/Checkbox.js
+++ b/components/atoms/Inputs/Checkbox/Checkbox.js
@@ -1,6 +1,16 @@
 import PropTypes from 'prop-types'
 import {Field} from 'formik'
 
+/**
+ * Render Checkbox component.
+ *
+ * @param {object}        props           Input props.
+ * @param {string}        props.className Input className.
+ * @param {string|number} props.id        Input id.
+ * @param {string}        props.label     Input label.
+ * @param {string}        props.name      Input name.
+ * @return {Element}                      The Checkbox component.
+ */
 export default function Checkbox({className, id, label, name}) {
   return (
     <div className={className}>

--- a/components/atoms/Inputs/CheckboxGroup/CheckboxGroup.js
+++ b/components/atoms/Inputs/CheckboxGroup/CheckboxGroup.js
@@ -2,6 +2,17 @@ import PropTypes from 'prop-types'
 import {ErrorMessage} from 'formik'
 import Checkbox from '@/components/atoms/Inputs/Checkbox'
 
+/**
+ * Render CheckboxGroup component.
+ *
+ * @param {object}        props             CheckboxGroup props.
+ * @param {Array}         props.checkboxes  Array of checkbox data objects.
+ * @param {string}        props.className   CheckboxGroup wrapper className.
+ * @param {string|number} props.id          CheckboxGroup id.
+ * @param {string}        props.label       CheckboxGroup input label.
+ * @param {string}        props.description CheckboxGroup input name.
+ * @return {Element}                        The CheckboxGroup component.
+ */
 export default function CheckboxGroup({
   checkboxes,
   className,

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -1,5 +1,7 @@
 import {Field, ErrorMessage} from 'formik'
 import PropTypes from 'prop-types'
+import cn from 'classnames'
+import styles from './Select.module.css'
 
 /**
  * Render the Select component.
@@ -23,7 +25,7 @@ export default function Select({
   options
 }) {
   return (
-    <div className={className}>
+    <div className={cn(styles.select, className)}>
       {label && <label>{label}</label>}
       <Field as="select" id={id} name={id} required={isRequired}>
         {!!options?.length > 0 &&

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -1,3 +1,5 @@
+import {Field} from 'formik'
+
 /**
  * Render the Select component.
  *
@@ -6,13 +8,11 @@
  */
 export default function Select() {
   return (
-    <select>
+    <Field as="select" name="color">
       <option value="grapefruit">Grapefruit</option>
       <option value="lime">Lime</option>
-      <option selected value="coconut">
-        Coconut
-      </option>
+      <option value="coconut">Coconut</option>
       <option value="mango">Mango</option>
-    </select>
+    </Field>
   )
 }

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -1,4 +1,4 @@
-import {Field} from 'formik'
+import {Field, ErrorMessage} from 'formik'
 import PropTypes from 'prop-types'
 
 /**
@@ -37,6 +37,7 @@ export default function Select({
             )
           })}
         {description && <p>{description}</p>}
+        <ErrorMessage name={id} />
       </Field>
     </div>
   )

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -9,14 +9,15 @@ import PropTypes from 'prop-types'
  * @param {string} props.className   Select wrapper className.
  * @param {string} props.description Select description.
  * @param {string} props.label       Select input label.
+ * @param {string} props.id          Select input id.
  * @param {Array}  props.options     Array of input options objects.
  * @return {Element}             The Select component.
  */
-export default function Select({className, description, label, options}) {
+export default function Select({className, description, id, label, options}) {
   return (
     <div className={className}>
       {label && <label>{label}</label>}
-      <Field as="select" name="color">
+      <Field as="select" id={id} name={id}>
         {!!options?.length > 0 &&
           options.map((option, key) => {
             const {text, value} = option
@@ -36,6 +37,7 @@ export default function Select({className, description, label, options}) {
 Select.propTypes = {
   className: PropTypes.string,
   description: PropTypes.string,
+  id: PropTypes.string.isRequired,
   label: PropTypes.string,
   options: PropTypes.arrayOf([PropTypes.object])
 }

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -12,10 +12,16 @@ import PropTypes from 'prop-types'
 export default function Select({options}) {
   return (
     <Field as="select" name="color">
-      <option value="grapefruit">{options?.[0]}</option>
-      <option value="lime">Lime</option>
-      <option value="coconut">Coconut</option>
-      <option value="mango">Mango</option>
+      {!!options?.length > 0 &&
+        options.map((option, key) => {
+          const {text, value} = option
+
+          return (
+            <option key={key} value={value}>
+              {text}
+            </option>
+          )
+        })}
     </Field>
   )
 }

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -4,28 +4,33 @@ import PropTypes from 'prop-types'
 /**
  * Render the Select component.
  *
- * @param {object} props         props.
- * @param {Array}  props.options Array of input options objects.
  * @author WebDevStudios
+ * @param {object} props         props.
+ * @param {string} props.label   GravityForm field label.
+ * @param {Array}  props.options Array of input options objects.
  * @return {Element}             The Select component.
  */
-export default function Select({options}) {
+export default function Select({label, options}) {
   return (
-    <Field as="select" name="color">
-      {!!options?.length > 0 &&
-        options.map((option, key) => {
-          const {text, value} = option
+    <div>
+      {label && <label>{label}</label>}
+      <Field as="select" name="color">
+        {!!options?.length > 0 &&
+          options.map((option, key) => {
+            const {text, value} = option
 
-          return (
-            <option key={key} value={value}>
-              {text}
-            </option>
-          )
-        })}
-    </Field>
+            return (
+              <option key={key} value={value}>
+                {text}
+              </option>
+            )
+          })}
+      </Field>
+    </div>
   )
 }
 
 Select.propTypes = {
+  label: PropTypes.string,
   options: PropTypes.arrayOf([PropTypes.object])
 }

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -5,13 +5,14 @@ import PropTypes from 'prop-types'
  * Render the Select component.
  *
  * @author WebDevStudios
- * @param {object} props           props.
- * @param {string} props.className Select wrapper className.
- * @param {string} props.label     Select input label.
- * @param {Array}  props.options   Array of input options objects.
+ * @param {object} props             props.
+ * @param {string} props.className   Select wrapper className.
+ * @param {string} props.description Select description.
+ * @param {string} props.label       Select input label.
+ * @param {Array}  props.options     Array of input options objects.
  * @return {Element}             The Select component.
  */
-export default function Select({className, label, options}) {
+export default function Select({className, description, label, options}) {
   return (
     <div className={className}>
       {label && <label>{label}</label>}
@@ -26,6 +27,7 @@ export default function Select({className, label, options}) {
               </option>
             )
           })}
+        {description && <p>{description}</p>}
       </Field>
     </div>
   )
@@ -33,6 +35,7 @@ export default function Select({className, label, options}) {
 
 Select.propTypes = {
   className: PropTypes.string,
+  description: PropTypes.string,
   label: PropTypes.string,
   options: PropTypes.arrayOf([PropTypes.object])
 }

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -5,19 +5,27 @@ import PropTypes from 'prop-types'
  * Render the Select component.
  *
  * @author WebDevStudios
- * @param {object} props             props.
- * @param {string} props.className   Select wrapper className.
- * @param {string} props.description Select description.
- * @param {string} props.label       Select input label.
- * @param {string} props.id          Select input id.
- * @param {Array}  props.options     Array of input options objects.
- * @return {Element}             The Select component.
+ * @param {object}  props             props.
+ * @param {string}  props.className   Select wrapper className.
+ * @param {string}  props.description Select description.
+ * @param {string}  props.label       Select input label.
+ * @param {string}  props.id          Select input id.
+ * @param {boolean} props.isRequired  If input is required.
+ * @param {Array}   props.options     Array of input options objects.
+ * @return {Element}                  The Select component.
  */
-export default function Select({className, description, id, label, options}) {
+export default function Select({
+  className,
+  description,
+  id,
+  isRequired,
+  label,
+  options
+}) {
   return (
     <div className={className}>
       {label && <label>{label}</label>}
-      <Field as="select" id={id} name={id}>
+      <Field as="select" id={id} name={id} required={isRequired}>
         {!!options?.length > 0 &&
           options.map((option, key) => {
             const {text, value} = option
@@ -38,6 +46,11 @@ Select.propTypes = {
   className: PropTypes.string,
   description: PropTypes.string,
   id: PropTypes.string.isRequired,
+  isRequired: PropTypes.bool,
   label: PropTypes.string,
   options: PropTypes.arrayOf([PropTypes.object])
+}
+
+Select.defaultProps = {
+  isRequired: false
 }

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -5,14 +5,15 @@ import PropTypes from 'prop-types'
  * Render the Select component.
  *
  * @author WebDevStudios
- * @param {object} props         props.
- * @param {string} props.label   GravityForm field label.
- * @param {Array}  props.options Array of input options objects.
+ * @param {object} props           props.
+ * @param {string} props.className Select wrapper className.
+ * @param {string} props.label     Select input label.
+ * @param {Array}  props.options   Array of input options objects.
  * @return {Element}             The Select component.
  */
-export default function Select({label, options}) {
+export default function Select({className, label, options}) {
   return (
-    <div>
+    <div className={className}>
       {label && <label>{label}</label>}
       <Field as="select" name="color">
         {!!options?.length > 0 &&
@@ -31,6 +32,7 @@ export default function Select({label, options}) {
 }
 
 Select.propTypes = {
+  className: PropTypes.string,
   label: PropTypes.string,
   options: PropTypes.arrayOf([PropTypes.object])
 }

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -1,18 +1,25 @@
 import {Field} from 'formik'
+import PropTypes from 'prop-types'
 
 /**
  * Render the Select component.
  *
+ * @param {object} props         props.
+ * @param {Array}  props.options Array of input options objects.
  * @author WebDevStudios
- * @return {Element} The Select component.
+ * @return {Element}             The Select component.
  */
-export default function Select() {
+export default function Select({options}) {
   return (
     <Field as="select" name="color">
-      <option value="grapefruit">Grapefruit</option>
+      <option value="grapefruit">{options?.[0]}</option>
       <option value="lime">Lime</option>
       <option value="coconut">Coconut</option>
       <option value="mango">Mango</option>
     </Field>
   )
+}
+
+Select.propTypes = {
+  options: PropTypes.arrayOf([PropTypes.object])
 }

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -37,8 +37,8 @@ export default function Select({
             )
           })}
         {description && <p>{description}</p>}
-        <ErrorMessage name={id} />
       </Field>
+      <ErrorMessage name={id} />
     </div>
   )
 }

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -48,7 +48,7 @@ Select.propTypes = {
   id: PropTypes.string.isRequired,
   isRequired: PropTypes.bool,
   label: PropTypes.string,
-  options: PropTypes.arrayOf([PropTypes.object])
+  options: PropTypes.arrayOf(PropTypes.object)
 }
 
 Select.defaultProps = {

--- a/components/atoms/Inputs/Select/Select.js
+++ b/components/atoms/Inputs/Select/Select.js
@@ -1,0 +1,18 @@
+/**
+ * Render the Select component.
+ *
+ * @author WebDevStudios
+ * @return {Element} The Select component.
+ */
+export default function Select() {
+  return (
+    <select>
+      <option value="grapefruit">Grapefruit</option>
+      <option value="lime">Lime</option>
+      <option selected value="coconut">
+        Coconut
+      </option>
+      <option value="mango">Mango</option>
+    </select>
+  )
+}

--- a/components/atoms/Inputs/Select/Select.module.css
+++ b/components/atoms/Inputs/Select/Select.module.css
@@ -1,0 +1,5 @@
+.select {
+  & select {
+    @apply block border;
+  }
+}

--- a/components/atoms/Inputs/Select/index.js
+++ b/components/atoms/Inputs/Select/index.js
@@ -1,0 +1,1 @@
+export {default} from './Select'

--- a/components/atoms/Inputs/index.js
+++ b/components/atoms/Inputs/index.js
@@ -1,3 +1,4 @@
 export {default as Checkbox} from './Checkbox'
 export {default as CheckboxGroup} from './CheckboxGroup'
+export {default as Select} from './Select'
 export {default as Text} from './Text'

--- a/components/molecules/GravityForm/Fields/Checkbox.js
+++ b/components/molecules/GravityForm/Fields/Checkbox.js
@@ -3,6 +3,19 @@ import {getGfFieldId, getGfHiddenClassName} from '@/functions/gravityForms'
 import cn from 'classnames'
 import * as Input from '@/components/atoms/Inputs'
 
+/**
+ * Render GravityForms Checkbox field component.
+ *
+ * @param {object}        props             GravityForm Checkbox field props.
+ * @param {string}        props.className   GravityForm field wrapper class.
+ * @param {string}        props.description GravityForm field description.
+ * @param {Array}         props.inputs      Array of checkbox field input data.
+ * @param {string|number} props.id          GravityForm field id.
+ * @param {string}        props.label       GravityForm field label.
+ * @param {string}        props.size        GravityForm field size.
+ * @param {boolean}       props.visibility  GravityForm field visibility.
+ * @return {Element}                        The Checkbox component.
+ */
 export default function Checkbox({
   className,
   description,

--- a/components/molecules/GravityForm/Fields/Fields.js
+++ b/components/molecules/GravityForm/Fields/Fields.js
@@ -51,6 +51,10 @@ export default function Fields({fields, setFormValidation}) {
               fieldToRender = <GfFields.Text {...field.node} key={id} />
               break
 
+            case 'select':
+              fieldToRender = <GfFields.Select {...field.node} key={id} />
+              break
+
             case 'text':
               fieldToRender = <GfFields.Text {...field.node} key={id} />
               break

--- a/components/molecules/GravityForm/Fields/Select.js
+++ b/components/molecules/GravityForm/Fields/Select.js
@@ -34,9 +34,11 @@ export default function Select({
       className={cn(className, isHiddenClass) || null}
       field-size={size && `size-${size}`}
     >
-      {description}
-      {label}
-      <Input.Select options={selectChoices} />
+      <Input.Select
+        description={description}
+        label={label}
+        options={selectChoices}
+      />
     </div>
   )
 }

--- a/components/molecules/GravityForm/Fields/Select.js
+++ b/components/molecules/GravityForm/Fields/Select.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import {getGfFieldId, getGfHiddenClassName} from '@/functions/gravityForms'
+import * as Input from '@/components/atoms/Inputs'
 import cn from 'classnames'
 
 /**
@@ -40,6 +41,7 @@ export default function Select({
 
         return <p key={key}>{`${text} | ${value} | ${isSelected}`}</p>
       })}
+      <Input.Select />
     </div>
   )
 }

--- a/components/molecules/GravityForm/Fields/Select.js
+++ b/components/molecules/GravityForm/Fields/Select.js
@@ -30,11 +30,11 @@ export default function Select({
 
   return (
     <div
-      id={fieldId}
       className={cn(className, isHiddenClass) || null}
       field-size={size && `size-${size}`}
     >
       <Input.Select
+        id={fieldId}
         description={description}
         label={label}
         options={selectChoices}

--- a/components/molecules/GravityForm/Fields/Select.js
+++ b/components/molecules/GravityForm/Fields/Select.js
@@ -36,12 +36,7 @@ export default function Select({
     >
       {description}
       {label}
-      {selectChoices.map((option, key) => {
-        const {isSelected, text, value} = option
-
-        return <p key={key}>{`${text} | ${value} | ${isSelected}`}</p>
-      })}
-      <Input.Select />
+      <Input.Select options={selectChoices} />
     </div>
   )
 }

--- a/components/molecules/GravityForm/Fields/Select.js
+++ b/components/molecules/GravityForm/Fields/Select.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import {getGfFieldId, getGfHiddenClassName} from '@/functions/gravityForms'
 import cn from 'classnames'
-import * as Input from '@/components/atoms/Inputs'
 
 /**
  * Render GravityForms Checkbox field component.
@@ -9,7 +8,6 @@ import * as Input from '@/components/atoms/Inputs'
  * @param {object}        props             GravityForm Checkbox field props.
  * @param {string}        props.className   GravityForm field wrapper class.
  * @param {string}        props.description GravityForm field description.
- * @param {Array}         props.inputs      Array of checkbox field input data.
  * @param {string|number} props.id          GravityForm field id.
  * @param {string}        props.label       GravityForm field label.
  * @param {string}        props.size        GravityForm field size.
@@ -20,7 +18,6 @@ export default function Select({
   className,
   description,
   id,
-  inputs,
   label,
   size,
   visibility
@@ -30,15 +27,12 @@ export default function Select({
 
   return (
     <div
+      id={fieldId}
       className={cn(className, isHiddenClass) || null}
       field-size={size && `size-${size}`}
     >
-      <Input.CheckboxGroup
-        checkboxes={inputs}
-        description={description}
-        id={fieldId}
-        label={label}
-      />
+      {description}
+      {label}
     </div>
   )
 }
@@ -47,7 +41,6 @@ Select.propTypes = {
   className: PropTypes.string,
   description: PropTypes.string,
   id: PropTypes.number.isRequired,
-  inputs: PropTypes.arrayOf(PropTypes.object),
   label: PropTypes.string,
   size: PropTypes.string,
   visibility: PropTypes.string

--- a/components/molecules/GravityForm/Fields/Select.js
+++ b/components/molecules/GravityForm/Fields/Select.js
@@ -10,16 +10,18 @@ import cn from 'classnames'
  * @param {string}        props.className     GravityForm field wrapper class.
  * @param {string}        props.description   GravityForm field description.
  * @param {string|number} props.id            GravityForm field id.
+ * @param {boolean}       props.isRequired    GravityForm field is required.
  * @param {string}        props.label         GravityForm field label.
  * @param {string}        props.size          GravityForm field size.
  * @param {Array}         props.selectChoices GravityForm field selection options.
  * @param {boolean}       props.visibility    GravityForm field visibility.
- * @return {Element}                        The Checkbox component.
+ * @return {Element}                          The Checkbox component.
  */
 export default function Select({
   className,
   description,
   id,
+  isRequired,
   label,
   size,
   selectChoices,
@@ -35,6 +37,7 @@ export default function Select({
     >
       <Input.Select
         id={fieldId}
+        isRequired={isRequired}
         description={description}
         label={label}
         options={selectChoices}
@@ -47,6 +50,7 @@ Select.propTypes = {
   className: PropTypes.string,
   description: PropTypes.string,
   id: PropTypes.number.isRequired,
+  isRequired: PropTypes.bool,
   label: PropTypes.string,
   selectChoices: PropTypes.arrayOf([PropTypes.object]),
   size: PropTypes.string,

--- a/components/molecules/GravityForm/Fields/Select.js
+++ b/components/molecules/GravityForm/Fields/Select.js
@@ -52,7 +52,7 @@ Select.propTypes = {
   id: PropTypes.number.isRequired,
   isRequired: PropTypes.bool,
   label: PropTypes.string,
-  selectChoices: PropTypes.arrayOf([PropTypes.object]),
+  selectChoices: PropTypes.arrayOf(PropTypes.object),
   size: PropTypes.string,
   visibility: PropTypes.string
 }

--- a/components/molecules/GravityForm/Fields/Select.js
+++ b/components/molecules/GravityForm/Fields/Select.js
@@ -5,13 +5,14 @@ import cn from 'classnames'
 /**
  * Render GravityForms Checkbox field component.
  *
- * @param {object}        props             GravityForm Checkbox field props.
- * @param {string}        props.className   GravityForm field wrapper class.
- * @param {string}        props.description GravityForm field description.
- * @param {string|number} props.id          GravityForm field id.
- * @param {string}        props.label       GravityForm field label.
- * @param {string}        props.size        GravityForm field size.
- * @param {boolean}       props.visibility  GravityForm field visibility.
+ * @param {object}        props               GravityForm Checkbox field props.
+ * @param {string}        props.className     GravityForm field wrapper class.
+ * @param {string}        props.description   GravityForm field description.
+ * @param {string|number} props.id            GravityForm field id.
+ * @param {string}        props.label         GravityForm field label.
+ * @param {string}        props.size          GravityForm field size.
+ * @param {Array}         props.selectChoices GravityForm field selection options.
+ * @param {boolean}       props.visibility    GravityForm field visibility.
  * @return {Element}                        The Checkbox component.
  */
 export default function Select({
@@ -20,6 +21,7 @@ export default function Select({
   id,
   label,
   size,
+  selectChoices,
   visibility
 }) {
   const fieldId = getGfFieldId(id)
@@ -33,6 +35,11 @@ export default function Select({
     >
       {description}
       {label}
+      {selectChoices.map((option, key) => {
+        const {isSelected, text, value} = option
+
+        return <p key={key}>{`${text} | ${value} | ${isSelected}`}</p>
+      })}
     </div>
   )
 }
@@ -42,6 +49,7 @@ Select.propTypes = {
   description: PropTypes.string,
   id: PropTypes.number.isRequired,
   label: PropTypes.string,
+  selectChoices: PropTypes.arrayOf([PropTypes.object]),
   size: PropTypes.string,
   visibility: PropTypes.string
 }

--- a/components/molecules/GravityForm/Fields/Select.js
+++ b/components/molecules/GravityForm/Fields/Select.js
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types'
+import {getGfFieldId, getGfHiddenClassName} from '@/functions/gravityForms'
+import cn from 'classnames'
+import * as Input from '@/components/atoms/Inputs'
+
+/**
+ * Render GravityForms Checkbox field component.
+ *
+ * @param {object}        props             GravityForm Checkbox field props.
+ * @param {string}        props.className   GravityForm field wrapper class.
+ * @param {string}        props.description GravityForm field description.
+ * @param {Array}         props.inputs      Array of checkbox field input data.
+ * @param {string|number} props.id          GravityForm field id.
+ * @param {string}        props.label       GravityForm field label.
+ * @param {string}        props.size        GravityForm field size.
+ * @param {boolean}       props.visibility  GravityForm field visibility.
+ * @return {Element}                        The Checkbox component.
+ */
+export default function Select({
+  className,
+  description,
+  id,
+  inputs,
+  label,
+  size,
+  visibility
+}) {
+  const fieldId = getGfFieldId(id)
+  const isHiddenClass = getGfHiddenClassName(visibility)
+
+  return (
+    <div
+      className={cn(className, isHiddenClass) || null}
+      field-size={size && `size-${size}`}
+    >
+      <Input.CheckboxGroup
+        checkboxes={inputs}
+        description={description}
+        id={fieldId}
+        label={label}
+      />
+    </div>
+  )
+}
+
+Select.propTypes = {
+  className: PropTypes.string,
+  description: PropTypes.string,
+  id: PropTypes.number.isRequired,
+  inputs: PropTypes.arrayOf(PropTypes.object),
+  label: PropTypes.string,
+  size: PropTypes.string,
+  visibility: PropTypes.string
+}

--- a/components/molecules/GravityForm/Fields/index.js
+++ b/components/molecules/GravityForm/Fields/index.js
@@ -1,3 +1,4 @@
 export {default} from './Fields'
 export {default as Checkbox} from './Checkbox'
+export {default as Select} from './Select'
 export {default as Text} from './Text'

--- a/functions/gravityForms/getGfFieldValidationSchema.js
+++ b/functions/gravityForms/getGfFieldValidationSchema.js
@@ -32,6 +32,10 @@ function getValidationSchemaByType(fieldData) {
       schemaGetter = new StringSchemaFactory(fieldData).schema
       break
 
+    case 'select':
+      schemaGetter = new StringSchemaFactory(fieldData).schema
+      break
+
     case 'website':
       schemaGetter = new StringSchemaFactory(fieldData).schema
       break


### PR DESCRIPTION
Part of  https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/45

### Link
https://nextjs-wordpress-starter-kcjbofp7b.vercel.app/form-demo

### Description

Create the following components necessary for the Dropdown field in GravityForms. This update also includes doc block on files that were updated.

**Components**
- Select input component
- Select GravityForm field type component

**Updates**
- Integrate Select GravityForm field into Fields
- Integrate Select GravityForm field into validationSchema. This field utilizes the StringSchemaFactory and did not require additional methods for validation.
- Add doc blocks to Checkbox, CheckboxGroup, and GF Checkbox field and more...
- Added support for various GravityForm settings on select field
- Setup very basic styles on Select field

### Screenshot
**Select field in action**

![selection feature](https://user-images.githubusercontent.com/25035900/104755110-09397180-5728-11eb-810f-cdc487a195c8.gif)

**Example of form submission**

<img width="436" alt="Screen Shot 2021-01-15 at 11 50 01 AM" src="https://user-images.githubusercontent.com/25035900/104755137-12c2d980-5728-11eb-9f5d-59263ea27300.png">

**Example of the required select field**

![validation-works](https://user-images.githubusercontent.com/25035900/104754638-76003c00-5727-11eb-855c-5a92c91d17ea.gif)

### Verification

1. Experiment with the select field.
