### PR TITLE
Feature/60 basic comment form

### DIFF
--- a/api/frontend/wp/comments/postComment.js
+++ b/api/frontend/wp/comments/postComment.js
@@ -45,7 +45,7 @@ export default async function postComment(
     })
     .then(
       (response) =>
-        response?.data?.createComment ?? {
+        response?.data?.postComment ?? {
           error: true,
           errorMessage: `An error occurred while trying to post the comment.`
         }

--- a/components/molecules/Form/Form.js
+++ b/components/molecules/Form/Form.js
@@ -13,6 +13,7 @@ import cn from 'classnames'
  * @param {object}        props.formDefaults     Formik default data.
  * @param {string|number} props.id               Form id.
  * @param {object}        props.validationSchema Yup validation schema object.
+ * @param {function}      props.onSubmit         Function to execute when form is submitted
  * @return {Element}                             The Form component.
  */
 export default function Form({
@@ -20,18 +21,14 @@ export default function Form({
   className,
   formDefaults,
   id,
-  validationSchema
+  validationSchema,
+  onSubmit
 }) {
   return (
     <Formik
       initialValues={formDefaults}
       validationSchema={validationSchema}
-      onSubmit={(values, {setSubmitting}) => {
-        setTimeout(() => {
-          alert(JSON.stringify(values, null, 2))
-          setSubmitting(false)
-        }, 400)
-      }}
+      onSubmit={onSubmit}
     >
       <FormikForm id={id} className={cn(styles.form, className)}>
         {children}
@@ -46,7 +43,8 @@ Form.propTypes = {
   className: PropTypes.string,
   formDefaults: PropTypes.object,
   id: PropTypes.string,
-  validationSchema: PropTypes.object
+  validationSchema: PropTypes.object,
+  onSubmit: PropTypes.function
 }
 
 Form.defaultProps = {

--- a/components/molecules/Form/Form.js
+++ b/components/molecules/Form/Form.js
@@ -13,7 +13,7 @@ import cn from 'classnames'
  * @param {object}        props.formDefaults     Formik default data.
  * @param {string|number} props.id               Form id.
  * @param {object}        props.validationSchema Yup validation schema object.
- * @param {function}      props.onSubmit         Function to execute when form is submitted
+ * @param {Function}      props.onSubmit         Function to execute when form is submitted
  * @return {Element}                             The Form component.
  */
 export default function Form({

--- a/components/molecules/Form/Form.js
+++ b/components/molecules/Form/Form.js
@@ -44,7 +44,7 @@ Form.propTypes = {
   formDefaults: PropTypes.object,
   id: PropTypes.string,
   validationSchema: PropTypes.object,
-  onSubmit: PropTypes.function
+  onSubmit: PropTypes.func
 }
 
 Form.defaultProps = {

--- a/pages/api/wp/postComment.js
+++ b/pages/api/wp/postComment.js
@@ -33,7 +33,8 @@ export default async function postComment(req, res) {
     res
       .status(error?.status || 500)
       .end(
-        error?.message || 'An error occurred while attempted to load more posts'
+        error?.message ||
+          'An error occurred while attempted to post the comment'
       )
   }
 }

--- a/pages/blog/[[...slug]].js
+++ b/pages/blog/[[...slug]].js
@@ -6,6 +6,9 @@ import getArchivePosts from '@/api/frontend/wp/archive/getArchivePosts'
 import postComment from '@/api/frontend/wp/comments/postComment'
 import getPagePropTypes from '@/functions/getPagePropTypes'
 import Blocks from '@/components/molecules/Blocks'
+import Form from '@/components/molecules/Form'
+import {Field, ErrorMessage} from 'formik'
+import * as Yup from 'yup'
 
 // Define route post type.
 const postType = 'post'
@@ -28,20 +31,6 @@ export default function BlogPost({post, archive, posts, pagination}) {
   async function loadPosts() {
     // TODO: use response to display next "page" of posts.
     await getArchivePosts(postType, pagination?.endCursor)
-  }
-
-  /**
-   * Post a comment back to the blog
-   */
-  async function postTestComment() {
-    // TODO: get form data and post the comment
-    await postComment(
-      'Test Testerson',
-      'test@nextjswp.test',
-      'https://nextjswp.test',
-      post.databaseId,
-      'This is a test comment.'
-    )
   }
 
   // Check for post archive.
@@ -84,7 +73,60 @@ export default function BlogPost({post, archive, posts, pagination}) {
             __html: JSON.stringify(post?.comments ?? [])
           }}
         />
-        <button onClick={postTestComment}>Post test comment</button>
+
+        <Form
+          className="sample-form"
+          id="form-1"
+          title="Add a comment"
+          validationSchema={Yup.object().shape({
+            author: Yup.string().required('This field is required.'),
+            authorEmail: Yup.string().required('This field is required.')
+          })}
+          onSubmit={async (values, {setSubmitting}) => {
+            const {author, authorEmail, authorUrl, content} = values
+            await postComment(
+              author,
+              authorEmail,
+              authorUrl,
+              post.databaseId,
+              content
+            )
+            setSubmitting(false)
+          }}
+        >
+          <label htmlFor="author">Author</label>
+          <Field
+            id="author"
+            name="author"
+            placeholder="Test Testerson"
+            type="text"
+          />
+          <ErrorMessage name="author" />
+          <label htmlFor="authorEmail">Email</label>
+          <Field
+            id="authorEmail"
+            name="authorEmail"
+            placeholder="test@nextjswp.local"
+            type="email"
+          />
+          <ErrorMessage name="authorEmail" />
+          <label htmlFor="authorUrl">Website</label>
+          <Field
+            id="authorUrl"
+            name="authorUrl"
+            placeholder="https://nextjswp.local"
+            type="url"
+          />
+          <ErrorMessage name="authorUrl" />
+          <label htmlFor="content">Comment</label>
+          <Field
+            id="content"
+            name="content"
+            placeholder="This is a test comment"
+            type="textarea"
+          />
+          <ErrorMessage name="content" />
+        </Form>
       </article>
     </Layout>
   )

--- a/pages/blog/[[...slug]].js
+++ b/pages/blog/[[...slug]].js
@@ -7,7 +7,7 @@ import postComment from '@/api/frontend/wp/comments/postComment'
 import getPagePropTypes from '@/functions/getPagePropTypes'
 import Blocks from '@/components/molecules/Blocks'
 import Form from '@/components/molecules/Form'
-import {Field, ErrorMessage} from 'formik'
+import Text from '@/components/atoms/Inputs/Text'
 import * as Yup from 'yup'
 
 // Define route post type.
@@ -94,38 +94,10 @@ export default function BlogPost({post, archive, posts, pagination}) {
             setSubmitting(false)
           }}
         >
-          <label htmlFor="author">Author</label>
-          <Field
-            id="author"
-            name="author"
-            placeholder="Test Testerson"
-            type="text"
-          />
-          <ErrorMessage name="author" />
-          <label htmlFor="authorEmail">Email</label>
-          <Field
-            id="authorEmail"
-            name="authorEmail"
-            placeholder="test@nextjswp.local"
-            type="email"
-          />
-          <ErrorMessage name="authorEmail" />
-          <label htmlFor="authorUrl">Website</label>
-          <Field
-            id="authorUrl"
-            name="authorUrl"
-            placeholder="https://nextjswp.local"
-            type="url"
-          />
-          <ErrorMessage name="authorUrl" />
-          <label htmlFor="content">Comment</label>
-          <Field
-            id="content"
-            name="content"
-            placeholder="This is a test comment"
-            type="textarea"
-          />
-          <ErrorMessage name="content" />
+          <Text id="author" label="Author" isRequired type="text" />
+          <Text id="authorEmail" label="Email" isRequired type="email" />
+          <Text id="authorUrl" label="Website" type="url" />
+          <Text id="content" label="Comment" isRequired type="text" />
         </Form>
       </article>
     </Layout>

--- a/pages/blog/[[...slug]].js
+++ b/pages/blog/[[...slug]].js
@@ -84,13 +84,16 @@ export default function BlogPost({post, archive, posts, pagination}) {
           })}
           onSubmit={async (values, {setSubmitting}) => {
             const {author, authorEmail, authorUrl, content} = values
-            await postComment(
+            const response = await postComment(
               author,
               authorEmail,
               authorUrl,
               post.databaseId,
               content
             )
+            response.error
+              ? alert(response.errorMessage)
+              : alert(JSON.stringify(response))
             setSubmitting(false)
           }}
         >


### PR DESCRIPTION
In support of #60 

### Link

[Vercel preview](https://nextjs-wordpress-starter-lrgvojerm.vercel.app/)

### Description

Adds a basic comment form to the bottom of the post page. This allows end-to-end testing of the comment functionality.

### Screenshot

<img width="215" alt="image" src="https://user-images.githubusercontent.com/1427716/105892239-96f64600-5fdf-11eb-9a88-7820edd4fd47.png">


### Verification

How will a stakeholder test this?

1. Fill out the comment form.
1. If moderation is turned off/does not apply, note the alert with the comment response. Otherwise, note the alert with the error.
1. View the WordPress backend and see the comment there (either posted or awaiting approval)
