### PR TITLE
Add innerBlocks to formatted blocks

### DIFF
--- a/functions/displayBlock.js
+++ b/functions/displayBlock.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types'
  * @author WebDevStudios
  * @param {object} block The block data.
  * @param {number} index A unique key required by React.
- * @return {Element} A block-based component.
+ * @return {Element}     A block-based component.
  */
 export default function displayBlock(block, index) {
   const {attributes, name} = block

--- a/functions/displayBlock.js
+++ b/functions/displayBlock.js
@@ -43,7 +43,7 @@ export default function displayBlock(block, index) {
     case 'core/spacer':
       return <Blocks.BlockSpacer {...attributes} key={index} />
     default:
-      return <pre key={index}>{JSON.stringify(attributes, null, 2)}</pre>
+      return <pre key={index}>{JSON.stringify(block, null, 2)}</pre>
   }
 }
 

--- a/functions/formatBlockData.js
+++ b/functions/formatBlockData.js
@@ -4,8 +4,8 @@ import getFormById from '@/api/wordpress/gravityForms/getFormById'
  * Format and retrieve expanded block data.
  *
  * @author WebDevStudios
- * @param  {Array} blocks Basic block data.
- * @return {Array}        Formatted block data.
+ * @param {Array} blocks Basic block data.
+ * @return {Array}       Formatted block data.
  */
 export default async function formatBlockData(blocks) {
   if (!blocks || !blocks.length) {
@@ -14,7 +14,7 @@ export default async function formatBlockData(blocks) {
 
   return await Promise.all(
     blocks.map(async (block) => {
-      const {name, attributes} = block
+      const {name, attributes, innerBlocks} = block
 
       switch (name) {
         case 'gravityforms/form':
@@ -23,7 +23,9 @@ export default async function formatBlockData(blocks) {
           break
       }
 
-      return {name, attributes}
+      const innerBlocksFormatted = await formatBlockData(innerBlocks)
+
+      return {name, attributes, innerBlocks: innerBlocksFormatted}
     })
   )
 }


### PR DESCRIPTION
In support of #115 

### Link

_preview link in progress_

### Description

Adds an `innerBlocks` property to the formatted Blocks data returned by WordPress. This will allow the frontend to see inner blocks for columns and other higher-order blocks.

### Screenshot

<img width="448" alt="image" src="https://user-images.githubusercontent.com/1427716/105911558-4c34f800-5ff8-11eb-8a27-f2e78f9e0301.png">


### Verification

1. Create a post with a Media-Image block
1. View it in the frontend and note the presence of `innerBlocks` in the displayed JSON
