### PR TITLE
Fix/color story

### DIFF
--- a/docs/Colors.stories.mdx
+++ b/docs/Colors.stories.mdx
@@ -199,9 +199,9 @@ Grey colors.
   </>
 </DocTable>
 
-# White and White Opacity
+# White
 
-White and white opacity shades.
+White color.
 
 <DocTable>
   <>
@@ -222,9 +222,9 @@ White and white opacity shades.
   </>
 </DocTable>
 
-# Black and Black Opacity
+# Black
 
-Black and black opacity shades.
+Black color.
 
 <DocTable>
   <>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -140,8 +140,8 @@ module.exports = {
         darker: '#333333',
         darkest: '#212121'
       },
-      white: '#FFFFFF',
-      black: '#000000',
+      white: {DEFAULT: '#FFFFFF'},
+      black: {DEFAULT: '#000000'},
       brand: {
         android: '#A4C639',
         behance: '#1769FF',


### PR DESCRIPTION
Closes https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/138

### Link

N/A

### Description

* Quick fix for the white and black colors

### Screenshot

![ 2021-01-27 at 10 25 00 ](https://user-images.githubusercontent.com/12365909/106013141-2ce6ab00-608a-11eb-9115-47f81111a8f2.png)

### Verification

How will a stakeholder test this?

1. Run storybook
2. Navigate to the colors documentation story
3. Verify that it looks like the screenshot above and that it's clear how to use the black and white colors
