### PR TITLE
Feature/60 comment spam protection

### DIFF
--- a/api/frontend/wp/comments/mutationAddComment.js
+++ b/api/frontend/wp/comments/mutationAddComment.js
@@ -18,6 +18,7 @@ const mutationAddComment = gql`
       postId: $postId,
       content: $content
     ) @rest(type: "Comments", path: "${wpDataEndpoints.postComment}?{args}") {
+      success
       comment {
         ${commentsFields}
       }

--- a/api/wordpress/_global/postCommentToPost.js
+++ b/api/wordpress/_global/postCommentToPost.js
@@ -36,6 +36,7 @@ export default async function postCommentToPost(
   // Set up return object.
   const response = {
     apolloClient,
+    success: false,
     comment: null
   }
 
@@ -61,6 +62,7 @@ export default async function postCommentToPost(
         return null
       }
 
+      response.success = data.createComment.success
       response.comment = data.createComment.comment
     })
     .catch((error) => {

--- a/api/wordpress/comments/mutationCommentToPost.js
+++ b/api/wordpress/comments/mutationCommentToPost.js
@@ -19,6 +19,7 @@ const mutationCommentToPost = gql`
         content: $content
       }
     ) {
+      success
       comment {
         ${commentsFields}
       }

--- a/pages/api/wp/postComment.js
+++ b/pages/api/wp/postComment.js
@@ -12,6 +12,15 @@ export default async function postComment(req, res) {
     // Retrieve props from request query params.
     const {author, authorEmail, authorUrl, postId, content} = req.query
 
+    // Basic check to see if the referer matches the host.
+    // This is trivially easy to bypass, but it's a first step.
+    if (
+      !req.headers.referer ||
+      !req.headers.referer.includes(req.headers.host)
+    ) {
+      throw new Error('Unauthorized access')
+    }
+
     const commentResponse = await postCommentToPost(
       author,
       authorEmail,


### PR DESCRIPTION
In support of #60 

### Link

[Vercel preview](https://nextjs-wordpress-starter-git-feature-60-comment-spam-protection.webdevstudios.vercel.app/)

### Description

On the FEEBEE call, it was mentioned that having some prevention against spam would be good, especially since comments are posted via an intentionally unprotected API endpoint. This PR adds some basic checks to the HTTP headers to catch unsophisticated attacks.

It should be noted that Akismet spam protection will work on the WordPress side, even on comments posted through GraphQL. There is also documentation available for [hitting Akismet's API directly](https://akismet.com/development/api/#comment-check) should that become necessary.

### Screenshot

<img width="605" alt="image" src="https://user-images.githubusercontent.com/1427716/106043742-d6d72f00-60ac-11eb-949b-189d40dbdb56.png">


### Verification

How will a stakeholder test this?

1. **Use a utility like cURL or Postman to manually post a comment to `http://localhost:3000/api/wp/postComment`.**
  - Note that it will not post unless the `referer` header is set to a `localhost:3000` URL.
  - The variables should be sent as HTTP variables, such as `http://localhost:3000/api/wp/postComment?author=Postman&authorEmail=123@fake.street&authorUrl=https://fake.street&postId=281&content=I am the punkin queen!`
2. **Post a comment normally using the form and verify that it works.**
3. **Post a guaranteed spam comment using the form**
  - From Akismet documentation, use author `viagra-test-123` and/or email `akismet-guaranteed-spam@example.com`
4. **Post a guaranteed spam comment using GraphQL directly on the WordPress server.**

I used the following GraphQL mutation to my personal blog's GraphQL endpoint. The result reported a server error but I was still able to see the comment in moderation.

```GraphQL
mutation ADD_COMMENT {
  createComment(input: {author: "viagra-test-123", authorEmail: "akismet-guaranteed-spam@example.com", authorUrl: "https://base.nowhere/~justine", commentOn: 298, content: "how do i"}) {
    success
    comment {
      databaseId
      content(format: RENDERED)
      parentDatabaseId
      approved
      id
      date
      parentId
      type
    }
  }
}
```
