### PR TITLE
Feature/add team fields

### DIFF
--- a/api/wordpress/teams/queryTeamById.js
+++ b/api/wordpress/teams/queryTeamById.js
@@ -14,6 +14,17 @@ const singleTeamFragment = gql`
     ${seoPostFields}
     ${authorPostFields}
     ${featuredImagePostFields}
+    teamMemberProfile {
+      facebookUrl
+      githubUrl
+      instagramUrl
+      linkedinUrl
+      location
+      websiteUrl
+      twitterUrl
+      title
+      wordpressorgProfileUrl
+    }
   }
 `
 

--- a/api/wordpress/teams/queryTeamsArchive.js
+++ b/api/wordpress/teams/queryTeamsArchive.js
@@ -10,6 +10,9 @@ const archiveTeamFragment = gql`
     ${globalPostFields}
     excerpt
     ${featuredImagePostFields}
+    teamMemberProfile {
+      easterEggUrl
+    }
   }
 `
 

--- a/pages/team/[[...slug]].js
+++ b/pages/team/[[...slug]].js
@@ -71,7 +71,33 @@ export default function Team({post, archive, posts, pagination}) {
             <Breadcrumbs breadcrumbs={post.seo.breadcrumbs} />
           )}
           <h1 dangerouslySetInnerHTML={{__html: post?.title}} />
+          <p>{post?.teamMemberProfile?.title}</p>
           <Blocks blocks={post?.blocks} />
+          {!!post?.teamMemberProfile && (
+            // Other profiles exist; this is a sample.
+            <ul>
+              {!!post.teamMemberProfile.facebookUrl && (
+                <li>
+                  <a href={post.teamMemberProfile.facebookUrl}>Facebook</a>
+                </li>
+              )}
+              {!!post.teamMemberProfile.linkedinUrl && (
+                <li>
+                  <a href={post.teamMemberProfile.linkedinUrl}>LinkedIn</a>
+                </li>
+              )}
+              {!!post.teamMemberProfile.twitterUrl && (
+                <li>
+                  <a href={post.teamMemberProfile.twitterUrl}>Twitter</a>
+                </li>
+              )}
+              {!!post.teamMemberProfile.githubUrl && (
+                <li>
+                  <a href={post.teamMemberProfile.githubUrl}>GitHub</a>
+                </li>
+              )}
+            </ul>
+          )}
         </article>
       </Container>
     </Layout>


### PR DESCRIPTION
### Link

https://nextjs-wordpress-starter-git-feature-add-team-fields.webdevstudios.vercel.app/

### Description

Add the team member fields to the WP queries and display extra info on team member pages.

### Screenshot

<img width="252" alt="Screen Shot 2021-02-04 at 9 50 11 AM" src="https://user-images.githubusercontent.com/1427716/106909600-7197c500-66ce-11eb-88d6-12ba96ec53de.png">

### Verification

How will a stakeholder test this?

1. Make sure the latest DB is pulled from WP Engine Dev
1. Install the PR and note the new fields showing.
