### PR TITLE
Set feedback for GF results

### DIFF
--- a/components/molecules/GravityForm/GravityForm.js
+++ b/components/molecules/GravityForm/GravityForm.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import React, {useState} from 'react'
 import Form from '@/components/molecules/Form'
 import Fields from './Fields'
 import getGfFormValidationSchema from '@/functions/gravityForms/getGfFormValidationSchema'
@@ -24,6 +25,8 @@ export default function GravityForm({
   const fieldData = fields?.edges
   const formValidationSchema = getGfFormValidationSchema(fieldData)
   const fieldDefaults = getGfFormDefaults(fieldData)
+
+  const [formFeedback, setFeedback] = useState(false)
 
   return (
     <Form
@@ -71,13 +74,24 @@ export default function GravityForm({
           method: 'POST',
           mimeType: 'multipart/form-data',
           body: formData
-        }).then((response) => response.json())
+        })
+          .then((response) => response.json())
+          .then((feedback) => setFeedback(feedback.confirmation_message))
+          .catch((error) => {
+            setFeedback(`Error in form submission: ${error.message}`)
+          })
       }}
     >
       {(formikProps) => (
         <>
           {title && <h2 className={styles.title}>{title}</h2>}
           {fieldData && <Fields fields={fieldData} formikProps={formikProps} />}
+          {!!formFeedback && (
+            <div
+              className="feedback"
+              dangerouslySetInnerHTML={{__html: formFeedback}}
+            />
+          )}
         </>
       )}
     </Form>


### PR DESCRIPTION
### Link

https://nextjs-wordpress-starter-git-feature-finishing-gravity-forms.webdevstudios.vercel.app/

### Description

GravityForms submission will now display feedback on submission of form.

### Screenshot

<img width="804" alt="image" src="https://user-images.githubusercontent.com/1427716/106923096-ba09af80-66db-11eb-86d7-dc3ec520ff62.png">

<img width="883" alt="image" src="https://user-images.githubusercontent.com/1427716/106924949-9d6e7700-66dd-11eb-9ff9-56a5d59b174e.png">


### Verification

How will a stakeholder test this?

1. Submit a GravityForm and note the response.
