### PR TITLE
fix tailwind Node 14 issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,10 @@
         "@storybook/addon-essentials": "^6.1.17",
         "@storybook/addon-links": "^6.1.17",
         "@storybook/react": "^6.1.17",
+        "@tailwindcss/postcss7-compat": "^2.0.3",
         "algoliasearch": "^4.8.5",
         "apollo-link-rest": "^0.8.0-beta.0",
+        "autoprefixer": "^9.8.6",
         "babel-loader": "^8.2.2",
         "chromatic": "^5.6.2",
         "dayjs": "^1.10.4",
@@ -40,6 +42,7 @@
         "hamburger-react": "^2.4.0",
         "next-seo": "^4.19.0",
         "next-sitemap": "^1.4.19",
+        "postcss": "^7.0.35",
         "postcss-flexbugs-fixes": "^4.2.1",
         "postcss-preset-env": "^6.7.0",
         "prettier": "^2.2.1",
@@ -52,7 +55,7 @@
         "storybook-css-modules-preset": "^1.0.6",
         "stylelint": "^13.9.0",
         "stylelint-config-standard": "^20.0.0",
-        "tailwindcss": "npm:@tailwindcss/postcss7-compat",
+        "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.3",
         "yup": "^0.32.8"
       },
       "engines": {
@@ -5894,6 +5897,59 @@
         "postcss-syntax": ">=0.36.2"
       }
     },
+    "node_modules/@tailwindcss/postcss7-compat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.0.3.tgz",
+      "integrity": "sha512-R43aiSzwlybDMhDld8vkSIKPSLXxbbmotZ+I2GIrX+IzFNy9JAByC7Ncf9A81Dg0JLBWHY5m769lBbBnJCF8cw==",
+      "dev": true,
+      "dependencies": {
+        "@fullhuman/postcss-purgecss": "^3.1.3",
+        "autoprefixer": "^9",
+        "bytes": "^3.0.0",
+        "chalk": "^4.1.0",
+        "color": "^3.1.3",
+        "detective": "^5.2.0",
+        "didyoumean": "^1.2.1",
+        "fs-extra": "^9.1.0",
+        "html-tags": "^3.1.0",
+        "lodash": "^4.17.20",
+        "modern-normalize": "^1.0.0",
+        "node-emoji": "^1.8.1",
+        "object-hash": "^2.1.1",
+        "postcss": "^7",
+        "postcss-functions": "^3",
+        "postcss-js": "^2",
+        "postcss-nested": "^4",
+        "postcss-selector-parser": "^6.0.4",
+        "postcss-value-parser": "^4.1.0",
+        "pretty-hrtime": "^1.0.3",
+        "reduce-css-calc": "^2.1.8",
+        "resolve": "^1.19.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/@tailwindcss/postcss7-compat/node_modules/chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -6658,27 +6714,13 @@
     },
     "node_modules/acorn-node": {
       "version": "1.8.2",
-      "resolved": "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
       "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^7.0.0",
         "acorn-walk": "^7.0.0",
         "xtend": "^4.0.2"
-      }
-    },
-    "node_modules/acorn-node/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -10614,10 +10656,9 @@
     },
     "node_modules/defined": {
       "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -10776,10 +10817,9 @@
     },
     "node_modules/detective": {
       "version": "5.2.0",
-      "resolved": "https://registry.yarnpkg.com/detective/-/detective-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
       "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
@@ -10794,10 +10834,9 @@
     },
     "node_modules/didyoumean": {
       "version": "1.2.1",
-      "resolved": "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
       "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=",
-      "dev": true,
-      "license": "Apache"
+      "dev": true
     },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
@@ -16874,10 +16913,9 @@
     },
     "node_modules/lodash.toarray": {
       "version": "4.4.0",
-      "resolved": "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -17801,10 +17839,9 @@
     },
     "node_modules/modern-normalize": {
       "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/modern-normalize/-/modern-normalize-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.0.0.tgz",
       "integrity": "sha512-1lM+BMLGuDfsdwf3rsgBSrxJwAZHFIrQ8YR61xIqdHo0uNKI9M52wNpHSrliZATJp51On6JD0AfRxd4YGSU0lw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -18242,10 +18279,9 @@
     },
     "node_modules/node-emoji": {
       "version": "1.10.0",
-      "resolved": "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
       "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash.toarray": "^4.4.0"
       }
@@ -19652,10 +19688,9 @@
     },
     "node_modules/postcss-functions": {
       "version": "3.0.0",
-      "resolved": "https://registry.yarnpkg.com/postcss-functions/-/postcss-functions-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
       "integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "glob": "^7.1.2",
         "object-assign": "^4.1.1",
@@ -19665,10 +19700,9 @@
     },
     "node_modules/postcss-functions/node_modules/postcss": {
       "version": "6.0.23",
-      "resolved": "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
       "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^2.4.1",
         "source-map": "^0.6.1",
@@ -19680,17 +19714,15 @@
     },
     "node_modules/postcss-functions/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/postcss-functions/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -19752,10 +19784,9 @@
     },
     "node_modules/postcss-js": {
       "version": "2.0.3",
-      "resolved": "https://registry.yarnpkg.com/postcss-js/-/postcss-js-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.3.tgz",
       "integrity": "sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1",
         "postcss": "^7.0.18"
@@ -19977,10 +20008,9 @@
     },
     "node_modules/postcss-nested": {
       "version": "4.2.3",
-      "resolved": "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
       "integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "postcss": "^7.0.32",
         "postcss-selector-parser": "^6.0.2"
@@ -24431,10 +24461,9 @@
     },
     "node_modules/tailwindcss/node_modules/chalk": {
       "version": "4.1.0",
-      "resolved": "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -31195,6 +31224,48 @@
         "unist-util-find-all-after": "^3.0.2"
       }
     },
+    "@tailwindcss/postcss7-compat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.0.3.tgz",
+      "integrity": "sha512-R43aiSzwlybDMhDld8vkSIKPSLXxbbmotZ+I2GIrX+IzFNy9JAByC7Ncf9A81Dg0JLBWHY5m769lBbBnJCF8cw==",
+      "dev": true,
+      "requires": {
+        "@fullhuman/postcss-purgecss": "^3.1.3",
+        "autoprefixer": "^9",
+        "bytes": "^3.0.0",
+        "chalk": "^4.1.0",
+        "color": "^3.1.3",
+        "detective": "^5.2.0",
+        "didyoumean": "^1.2.1",
+        "fs-extra": "^9.1.0",
+        "html-tags": "^3.1.0",
+        "lodash": "^4.17.20",
+        "modern-normalize": "^1.0.0",
+        "node-emoji": "^1.8.1",
+        "object-hash": "^2.1.1",
+        "postcss": "^7",
+        "postcss-functions": "^3",
+        "postcss-js": "^2",
+        "postcss-nested": "^4",
+        "postcss-selector-parser": "^6.0.4",
+        "postcss-value-parser": "^4.1.0",
+        "pretty-hrtime": "^1.0.3",
+        "reduce-css-calc": "^2.1.8",
+        "resolve": "^1.19.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -31850,21 +31921,13 @@
     },
     "acorn-node": {
       "version": "1.8.2",
-      "resolved": "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
       "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
       "dev": true,
       "requires": {
         "acorn": "^7.0.0",
         "acorn-walk": "^7.0.0",
         "xtend": "^4.0.2"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-          "dev": true
-        }
       }
     },
     "acorn-walk": {
@@ -34833,7 +34896,7 @@
     },
     "defined": {
       "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
@@ -34953,7 +35016,7 @@
     },
     "detective": {
       "version": "5.2.0",
-      "resolved": "https://registry.yarnpkg.com/detective/-/detective-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
       "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
       "dev": true,
       "requires": {
@@ -34964,7 +35027,7 @@
     },
     "didyoumean": {
       "version": "1.2.1",
-      "resolved": "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
       "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=",
       "dev": true
     },
@@ -39382,7 +39445,7 @@
     },
     "lodash.toarray": {
       "version": "4.4.0",
-      "resolved": "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
     },
@@ -40043,7 +40106,7 @@
     },
     "modern-normalize": {
       "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/modern-normalize/-/modern-normalize-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.0.0.tgz",
       "integrity": "sha512-1lM+BMLGuDfsdwf3rsgBSrxJwAZHFIrQ8YR61xIqdHo0uNKI9M52wNpHSrliZATJp51On6JD0AfRxd4YGSU0lw==",
       "dev": true
     },
@@ -40357,7 +40420,7 @@
     },
     "node-emoji": {
       "version": "1.10.0",
-      "resolved": "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
       "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
       "dev": true,
       "requires": {
@@ -41379,7 +41442,7 @@
     },
     "postcss-functions": {
       "version": "3.0.0",
-      "resolved": "https://registry.yarnpkg.com/postcss-functions/-/postcss-functions-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
       "integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
       "dev": true,
       "requires": {
@@ -41391,7 +41454,7 @@
       "dependencies": {
         "postcss": {
           "version": "6.0.23",
-          "resolved": "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
@@ -41402,13 +41465,13 @@
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
@@ -41457,7 +41520,7 @@
     },
     "postcss-js": {
       "version": "2.0.3",
-      "resolved": "https://registry.yarnpkg.com/postcss-js/-/postcss-js-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.3.tgz",
       "integrity": "sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==",
       "dev": true,
       "requires": {
@@ -41627,7 +41690,7 @@
     },
     "postcss-nested": {
       "version": "4.2.3",
-      "resolved": "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
       "integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
       "dev": true,
       "requires": {
@@ -44956,7 +45019,7 @@
       "dependencies": {
         "chalk": {
           "version": "4.1.0",
-          "resolved": "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build-storybook": "build-storybook",
     "chromatic": "npx chromatic --project-token zp8e8oo1lq",
     "clean": "rm -rf .next",
-    "dev": "next dev",
+    "dev": "npm run clean && next dev",
     "develop": "npm dev",
     "export": "next export",
     "format": "npx prettier --config=prettier.config.js '**/*.{js,jsx,ts,tsx,md,html,css,scss,json,yml}' --write || true",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,10 @@
     "@storybook/addon-essentials": "^6.1.17",
     "@storybook/addon-links": "^6.1.17",
     "@storybook/react": "^6.1.17",
+    "@tailwindcss/postcss7-compat": "^2.0.3",
     "algoliasearch": "^4.8.5",
     "apollo-link-rest": "^0.8.0-beta.0",
+    "autoprefixer": "^9.8.6",
     "babel-loader": "^8.2.2",
     "chromatic": "^5.6.2",
     "dayjs": "^1.10.4",
@@ -65,6 +67,7 @@
     "hamburger-react": "^2.4.0",
     "next-seo": "^4.19.0",
     "next-sitemap": "^1.4.19",
+    "postcss": "^7.0.35",
     "postcss-flexbugs-fixes": "^4.2.1",
     "postcss-preset-env": "^6.7.0",
     "prettier": "^2.2.1",
@@ -77,7 +80,7 @@
     "storybook-css-modules-preset": "^1.0.6",
     "stylelint": "^13.9.0",
     "stylelint-config-standard": "^20.0.0",
-    "tailwindcss": "npm:@tailwindcss/postcss7-compat",
+    "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.3",
     "yup": "^0.32.8"
   }
 }


### PR DESCRIPTION
It appears that with Node 14 (and Storybook, since it depends on PostCSS 7) you have to use the _Tailwind Compatibility Build_ as outlined here: https://tailwindcss.com/docs/installation#post-css-7-compatibility-build

- `tailwindcss@npm:@tailwindcss/postcss7-compat`
- `@tailwindcss/postcss7-compat`
- `postcss@^7` 
- `autoprefixer@^9`

This PR adds those packages. I've tested locally and both Next.js and Storybook build. Vercel was also successful 👍🏻