### PR TITLE
Reducing Bundle Size

### DIFF
--- a/components/blocks/ACF/AcfBlockMediaText/AcfBlockMediaText.js
+++ b/components/blocks/ACF/AcfBlockMediaText/AcfBlockMediaText.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types'
  * @param {object} props.attributes The attributes object.
  * @return {Element}                The component.
  */
-export default function LzbBlockMediaText({attributes}) {
+export default function AcfBlockMediaText({attributes}) {
   // TODO: Query the DB for the image ID and replace the attributes.data with the correct information.
   attributes.data = {
     ...attributes.data,
@@ -27,6 +27,6 @@ export default function LzbBlockMediaText({attributes}) {
   )
 }
 
-LzbBlockMediaText.propTypes = {
+AcfBlockMediaText.propTypes = {
   attributes: PropTypes.object
 }

--- a/components/blocks/Gutenberg/BlockCover/BlockCover.js
+++ b/components/blocks/Gutenberg/BlockCover/BlockCover.js
@@ -17,7 +17,7 @@ export default function BlockCover({media, innerBlocks}) {
   return (
     <>
       {!!media?.url && (
-        <Hero backgroundImage={media.url} id={media?.anchor}>
+        <Hero backgroundImage={media} id={media?.anchor}>
           {!!innerBlocks?.length && <Blocks blocks={innerBlocks} />}
         </Hero>
       )}

--- a/functions/displayBlock.js
+++ b/functions/displayBlock.js
@@ -1,5 +1,46 @@
-import * as Blocks from '@/components/blocks'
+import dynamic from 'next/dynamic'
 import PropTypes from 'prop-types'
+
+// Import WP blocks using Next Dynamic Imports
+// @see https://nextjs.org/docs/advanced-features/dynamic-import
+
+const BlockQuote = dynamic(() => import('@/blocks/Gutenberg/BlockQuote'))
+const BlockPullQuote = dynamic(() =>
+  import('@/blocks/Gutenberg/BlockPullQuote')
+)
+const BlockCode = dynamic(() => import('@/blocks/Gutenberg/BlockCode'))
+const BlockEmbed = dynamic(() => import('@/blocks/Gutenberg/BlockEmbed'))
+const BlockMediaText = dynamic(() =>
+  import('@/blocks/Gutenberg/BlockMediaText')
+)
+const BlockButton = dynamic(() => import('@/blocks/Gutenberg/BlockButton'))
+const BlockButtons = dynamic(() => import('@/blocks/Gutenberg/BlockButtons'))
+const BlockColumns = dynamic(() => import('@/blocks/Gutenberg/BlockColumns'))
+const BlockCover = dynamic(() => import('@/blocks/Gutenberg/BlockCover'))
+const BlockHeadings = dynamic(() => import('@/blocks/Gutenberg/BlockHeadings'))
+const BlockImage = dynamic(() => import('@/blocks/Gutenberg/BlockImage'))
+const BlockImageGallery = dynamic(() =>
+  import('@/blocks/Gutenberg/BlockImageGallery')
+)
+const BlockTable = dynamic(() => import('@/blocks/Gutenberg/BlockTable'))
+const BlockList = dynamic(() => import('@/blocks/Gutenberg/BlockList'))
+const BlockParagraph = dynamic(() =>
+  import('@/blocks/Gutenberg/BlockParagraph')
+)
+const BlockSeparator = dynamic(() =>
+  import('@/blocks/Gutenberg/BlockSeparator')
+)
+const BlockSpacer = dynamic(() => import('@/blocks/Gutenberg/BlockSpacer'))
+const BlockGravityForm = dynamic(() =>
+  import('@/blocks/Gutenberg/BlockGravityForm')
+)
+const LzbBlockMediaText = dynamic(() =>
+  import('@/blocks/LazyBlocks/LzbBlockMediaText')
+)
+const LzbBlockHero = dynamic(() => import('@/blocks/LazyBlocks/LzbBlockHero'))
+const AcfBlockMediaText = dynamic(() =>
+  import('@/blocks/ACF/AcfBlockMediaText')
+)
 
 /**
  * Decide which block component to display.
@@ -15,48 +56,48 @@ export default function displayBlock(block, index) {
   // prettier-ignore
   switch (name) {
     case 'core/quote':
-      return <Blocks.BlockQuote {...attributes} key={index} />
+      return <BlockQuote {...attributes} key={index} />
     case 'core/pullquote':
-      return <Blocks.BlockPullQuote {...attributes} key={index} />
+      return <BlockPullQuote {...attributes} key={index} />
     case 'core/code':
     case 'core/preformatted':
-      return <Blocks.BlockCode {...attributes} key={index} />
+      return <BlockCode {...attributes} key={index} />
     case 'core/embed':
-      return <Blocks.BlockEmbed {...attributes} key={index} />
+      return <BlockEmbed {...attributes} key={index} />
     case 'core/media-text':
-      return <Blocks.BlockMediaText media={attributes} innerBlocks={innerBlocks} key={index} />
+      return <BlockMediaText media={attributes} innerBlocks={innerBlocks} key={index} />
     case 'core/button':
-      return <Blocks.BlockButton {...attributes} key={index} />
+      return <BlockButton {...attributes} key={index} />
     case 'core/buttons':
-      return <Blocks.BlockButtons options={attributes} innerBlocks={innerBlocks} key={index} />
+      return <BlockButtons options={attributes} innerBlocks={innerBlocks} key={index} />
     case 'core/columns':
-      return  <Blocks.BlockColumns columns={attributes} innerBlocks={innerBlocks} key={index} />
+      return <BlockColumns columns={attributes} innerBlocks={innerBlocks} key={index} />
     case 'core/cover':
-      return <Blocks.BlockCover media={attributes} innerBlocks={innerBlocks} key={index} />
+      return <BlockCover media={attributes} innerBlocks={innerBlocks} key={index} />
     case 'core/heading':
-      return <Blocks.BlockHeadings {...attributes} key={index} />
+      return <BlockHeadings {...attributes} key={index} />
     case 'core/image':
-      return <Blocks.BlockImage {...attributes} key={index} />
+      return <BlockImage {...attributes} key={index} />
     case 'core/gallery':
-      return <Blocks.BlockImageGallery {...attributes} key={index} />
+      return <BlockImageGallery {...attributes} key={index} />
     case 'core/table':
-      return <Blocks.BlockTable {...attributes} key={index} />
+      return <BlockTable {...attributes} key={index} />
     case 'core/list':
-      return <Blocks.BlockList {...attributes} key={index} />
+      return <BlockList {...attributes} key={index} />
     case 'core/paragraph':
-      return <Blocks.BlockParagraph {...attributes} key={index} />
+      return <BlockParagraph {...attributes} key={index} />
     case 'core/separator':
-      return <Blocks.BlockSeparator {...attributes} key={index} />
+      return <BlockSeparator {...attributes} key={index} />
     case 'core/spacer':
-      return <Blocks.BlockSpacer {...attributes} key={index} />
+      return <BlockSpacer {...attributes} key={index} />
     case 'gravityforms/form':
-      return <Blocks.BlockGravityForm attributes={attributes} key={index} />
+      return <BlockGravityForm attributes={attributes} key={index} />
     case 'lazyblock/mediatext':
-      return <Blocks.LzbBlockMediaText attributes={attributes} key={index} />
+      return <LzbBlockMediaText attributes={attributes} key={index} />
     case 'lazyblock/hero':
-      return <Blocks.LzbBlockHero attributes={attributes} key={index} />
+      return <LzbBlockHero attributes={attributes} key={index} />
     case 'acf/acf-media-text':
-      return <Blocks.AcfBlockMediaText attributes={attributes} key={index} />
+      return <AcfBlockMediaText attributes={attributes} key={index} />
     default:
       return <pre key={index}>{JSON.stringify(block, null, 2)}</pre>
   }

--- a/functions/displayBlock.js
+++ b/functions/displayBlock.js
@@ -4,42 +4,68 @@ import PropTypes from 'prop-types'
 // Import WP blocks using Next Dynamic Imports
 // @see https://nextjs.org/docs/advanced-features/dynamic-import
 
-const BlockQuote = dynamic(() => import('@/blocks/Gutenberg/BlockQuote'))
+const BlockQuote = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockQuote')
+)
 const BlockPullQuote = dynamic(() =>
-  import('@/blocks/Gutenberg/BlockPullQuote')
+  import('@/components/blocks/Gutenberg/BlockPullQuote')
 )
-const BlockCode = dynamic(() => import('@/blocks/Gutenberg/BlockCode'))
-const BlockEmbed = dynamic(() => import('@/blocks/Gutenberg/BlockEmbed'))
+const BlockCode = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockCode')
+)
+const BlockEmbed = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockEmbed')
+)
 const BlockMediaText = dynamic(() =>
-  import('@/blocks/Gutenberg/BlockMediaText')
+  import('@/components/blocks/Gutenberg/BlockMediaText')
 )
-const BlockButton = dynamic(() => import('@/blocks/Gutenberg/BlockButton'))
-const BlockButtons = dynamic(() => import('@/blocks/Gutenberg/BlockButtons'))
-const BlockColumns = dynamic(() => import('@/blocks/Gutenberg/BlockColumns'))
-const BlockCover = dynamic(() => import('@/blocks/Gutenberg/BlockCover'))
-const BlockHeadings = dynamic(() => import('@/blocks/Gutenberg/BlockHeadings'))
-const BlockImage = dynamic(() => import('@/blocks/Gutenberg/BlockImage'))
+const BlockButton = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockButton')
+)
+const BlockButtons = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockButtons')
+)
+const BlockColumns = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockColumns')
+)
+const BlockCover = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockCover')
+)
+const BlockHeadings = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockHeadings')
+)
+const BlockImage = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockImage')
+)
 const BlockImageGallery = dynamic(() =>
-  import('@/blocks/Gutenberg/BlockImageGallery')
+  import('@/components/blocks/Gutenberg/BlockImageGallery')
 )
-const BlockTable = dynamic(() => import('@/blocks/Gutenberg/BlockTable'))
-const BlockList = dynamic(() => import('@/blocks/Gutenberg/BlockList'))
+const BlockTable = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockTable')
+)
+const BlockList = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockList')
+)
 const BlockParagraph = dynamic(() =>
-  import('@/blocks/Gutenberg/BlockParagraph')
+  import('@/components/blocks/Gutenberg/BlockParagraph')
 )
 const BlockSeparator = dynamic(() =>
-  import('@/blocks/Gutenberg/BlockSeparator')
+  import('@/components/blocks/Gutenberg/BlockSeparator')
 )
-const BlockSpacer = dynamic(() => import('@/blocks/Gutenberg/BlockSpacer'))
+const BlockSpacer = dynamic(() =>
+  import('@/components/blocks/Gutenberg/BlockSpacer')
+)
 const BlockGravityForm = dynamic(() =>
-  import('@/blocks/Gutenberg/BlockGravityForm')
+  import('@/components/blocks/Gutenberg/BlockGravityForm')
 )
 const LzbBlockMediaText = dynamic(() =>
-  import('@/blocks/LazyBlocks/LzbBlockMediaText')
+  import('@/components/blocks/LazyBlocks/LzbBlockMediaText')
 )
-const LzbBlockHero = dynamic(() => import('@/blocks/LazyBlocks/LzbBlockHero'))
+const LzbBlockHero = dynamic(() =>
+  import('@/components/blocks/LazyBlocks/LzbBlockHero')
+)
 const AcfBlockMediaText = dynamic(() =>
-  import('@/blocks/ACF/AcfBlockMediaText')
+  import('@/components/blocks/ACF/AcfBlockMediaText')
 )
 
 /**

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@/api/*": ["api/*"],
       "@/components/*": ["components/*"],
+      "@/blocks/*": ["components/blocks/*"],
       "@/functions/*": ["functions/*"],
       "@/styles/*": ["styles/*"]
     }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,7 +4,6 @@
     "paths": {
       "@/api/*": ["api/*"],
       "@/components/*": ["components/*"],
-      "@/blocks/*": ["components/blocks/*"],
       "@/functions/*": ["functions/*"],
       "@/styles/*": ["styles/*"]
     }


### PR DESCRIPTION
Partially Closes [#238 ]

### Link

View on [Vercel](https://nextjs-wordpress-starter-afavztzn8-webdevstudios.vercel.app//).

### Description
This PR reduces the initial JS bundle size by about 45% by importing blocks using Next.js Dynamic Imports. The new import method load blocks only when requested.
![image](https://user-images.githubusercontent.com/428624/109052147-4ab72800-76a9-11eb-84e1-a1a3217d561e.png)

Previously, all blocks were loaded up front causing large bundle sizes.

### Screenshot
![image](https://user-images.githubusercontent.com/428624/109051689-c06ec400-76a8-11eb-9145-7fe9b018d1ef.png)


### Verification

How will a stakeholder test this?

1. View on [Vercel](https://nextjs-wordpress-starter-afavztzn8-webdevstudios.vercel.app/)
1. View code
