### PR TITLE
Refactoring Context to export/import useContext hook.

### DIFF
--- a/components/common/WordPressProvider.js
+++ b/components/common/WordPressProvider.js
@@ -1,8 +1,13 @@
 import PropTypes from 'prop-types'
-import {createContext} from 'react'
+import {createContext, useContext} from 'react'
 
 // Initialize Menu context object.
 export const WPContext = createContext()
+
+// Export useContext Hook.
+export function useWordPressContext() {
+  return useContext(WPContext)
+}
 
 /**
  * Provide WordPress Context for components.

--- a/components/molecules/AlgoliaResults/AlgoliaResults.js
+++ b/components/molecules/AlgoliaResults/AlgoliaResults.js
@@ -1,7 +1,6 @@
-import {WPContext} from '@/components/common/WordPressProvider'
+import {useWordPressContext} from '@/components/common/WordPressProvider'
 import {searchResultsClient} from '@/lib/algolia/connector'
 import PropTypes from 'prop-types'
-import React, {useContext} from 'react'
 import {Configure, InstantSearch} from 'react-instantsearch-dom'
 import styles from './AlgoliaResults.module.css'
 import NoResults from './templates/NoResults'
@@ -18,7 +17,7 @@ import SearchResults from './templates/SearchResults'
  * @return {Element}            The AlgoliaResults component.
  */
 export default function AlgoliaResults({config}) {
-  const {algolia} = useContext(WPContext)
+  const {algolia} = useWordPressContext()
 
   // Dispatch console warning if Index Name missing.
   if (!algolia?.indexName) {

--- a/components/molecules/AlgoliaSearch/AlgoliaSearch.js
+++ b/components/molecules/AlgoliaSearch/AlgoliaSearch.js
@@ -1,10 +1,10 @@
-import {WPContext} from '@/components/common/WordPressProvider'
+import {useWordPressContext} from '@/components/common/WordPressProvider'
 import parseQuerystring from '@/functions/parseQuerystring'
 import cn from 'classnames'
 import dynamic from 'next/dynamic'
 import {useRouter} from 'next/router'
 import PropTypes from 'prop-types'
-import React, {useContext, useRef, useState} from 'react'
+import React, {useRef, useState} from 'react'
 import styles from './AlgoliaSearch.module.css'
 import SearchPlaceholder from './components/SearchPlaceholder'
 
@@ -34,7 +34,7 @@ export default function AlgoliaSearch({useHistory, usePlaceholder, className}) {
   const query = path.includes('q=') ? parseQuerystring(path, 'q') : '' // Parse the querystring.
   const [loadAlgolia, setLoadAlgolia] = useState(0)
   const searchRef = useRef()
-  const {algolia} = useContext(WPContext)
+  const {algolia} = useWordPressContext()
 
   /**
    * Set a min-height value on the search wrapper

--- a/components/organisms/Footer/Footer.js
+++ b/components/organisms/Footer/Footer.js
@@ -1,9 +1,8 @@
 import Container from '@/components/atoms/Container'
-import {WPContext} from '@/components/common/WordPressProvider'
+import {useWordPressContext} from '@/components/common/WordPressProvider'
 import {seoSocialPropTypes} from '@/functions/getPagePropTypes'
 import Link from 'next/link'
 import PropTypes from 'prop-types'
-import {useContext} from 'react'
 import styles from './Footer.module.css'
 
 // TODO: Create Storybook for this component.
@@ -18,7 +17,7 @@ import styles from './Footer.module.css'
  * @return {Element}               The Footer component.
  */
 export default function Footer({social, siteTitle}) {
-  const {menus} = useContext(WPContext)
+  const {menus} = useWordPressContext()
   return (
     <footer className={styles.footer}>
       <Container>

--- a/components/organisms/Header/Header.js
+++ b/components/organisms/Header/Header.js
@@ -1,10 +1,9 @@
 import Container from '@/components/atoms/Container'
 import Logo from '@/components/atoms/Logo'
-import {WPContext} from '@/components/common/WordPressProvider'
+import {useWordPressContext} from '@/components/common/WordPressProvider'
 import AlgoliaSearch from '@/components/molecules/AlgoliaSearch'
 import Navigation from '@/components/molecules/Navigation'
 import Link from 'next/link'
-import {useContext} from 'react'
 import styles from './Header.module.css'
 
 // TODO: Create Storybook for this component.
@@ -16,7 +15,7 @@ import styles from './Header.module.css'
  * @return {Element} The Header component.
  */
 export default function Header() {
-  const {menus} = useContext(WPContext)
+  const {menus} = useWordPressContext()
   return (
     <>
       <a className={styles.skip} href="#page-content">


### PR DESCRIPTION
Closes: N/A
### Link

[View on Vercel](https://nextjs-wordpress-starter-36mxpayak-webdevstudios.vercel.app/)

### Description

This PR refactors the `WordPressProvider` Context object to export a `useContext` hook directly from the component. This makes importing Context easier and more readable at the component level.

### Verification

How will a stakeholder test this?

1. View on [Vercel](https://nextjs-wordpress-starter-36mxpayak-webdevstudios.vercel.app/)
2. View code changes.
