### PR TITLE
feature/154-archive-seo

### DIFF
--- a/lib/wordpress/_global/getPostTypeArchive.js
+++ b/lib/wordpress/_global/getPostTypeArchive.js
@@ -1,9 +1,9 @@
-import {initializeWpApollo} from '../connector'
-import queryPostsArchive from '../posts/queryPostsArchive'
-import {postTypes} from './postTypes'
-import queryTeamsArchive from '../teams/queryTeamsArchive'
 import formatDefaultSeoData from '@/functions/formatDefaultSeoData'
+import {initializeWpApollo} from '../connector'
 import getMenus from '../menus/getMenus'
+import queryPostsArchive from '../posts/queryPostsArchive'
+import queryTeamsArchive from '../teams/queryTeamsArchive'
+import {postTypes} from './postTypes'
 
 // Define SEO for archives.
 export const archiveQuerySeo = {
@@ -77,7 +77,13 @@ export default async function getPostTypeArchive(
   await apolloClient
     .query({query, variables})
     .then((archive) => {
-      const {homepageSettings, siteSeo, menus, ...archiveData} = archive.data
+      const {
+        homepageSettings,
+        siteSeo,
+        menus,
+        seo,
+        ...archiveData
+      } = archive.data
 
       // Retrieve menus.
       response.menus = getMenus(menus)
@@ -117,8 +123,16 @@ export default async function getPostTypeArchive(
                 canonical: `${response.defaultSeo?.openGraph?.url ?? ''}/${
                   postTypes?.[postType]?.route
                 }`,
-                metaRobotsNofollow: 'follow',
-                metaRobotsNoindex: 'index'
+                metaRobotsNofollow:
+                  true ===
+                  seo?.contentTypes?.[postType]?.archive?.metaRobotsNoindex
+                    ? 'nofollow'
+                    : 'follow',
+                metaRobotsNoindex:
+                  true ===
+                  seo?.contentTypes?.[postType]?.archive?.metaRobotsNoindex
+                    ? 'noindex'
+                    : 'index'
               }
       }
 

--- a/lib/wordpress/teams/queryTeamsArchive.js
+++ b/lib/wordpress/teams/queryTeamsArchive.js
@@ -25,6 +25,15 @@ const queryTeamsArchive = gql`
     $imageSize: MediaItemSizeEnum = THUMBNAIL
   ) {
     ${defaultPageData}
+    seo {
+      contentTypes {
+        team {
+          archive {
+            metaRobotsNoindex
+          }
+        }
+      }
+    }
     teams(
       first: $first
       last: $last


### PR DESCRIPTION
Closes #154

### Link

https://nextjs-wordpress-starter-jilfvgfuk-webdevstudios.vercel.app/

### Description

Adds Team CPT archive SEO data to Team archive query (only `metaRobotsNoindex` so far).
Uses `metaRobotsNoindex` value to toggle CPT archive robots noindex and nofollow meta values.

### Screenshot

Team CPT archive `metaRobotsNoindex` set to `false`:
![Screen Shot 2021-03-23 at 10 26 02 AM](https://user-images.githubusercontent.com/36422618/112181851-65a28c80-8bc2-11eb-9b57-951ba175fc7e.png)

Team CPT archive `metaRobotsNoindex` set to `true`:
![Screen Shot 2021-03-23 at 10 26 18 AM](https://user-images.githubusercontent.com/36422618/112181854-663b2300-8bc2-11eb-9f01-3ce7d2b13bd7.png)

Setting to toggle:
![Screen Shot 2021-03-23 at 10 26 28 AM](https://user-images.githubusercontent.com/36422618/112181855-663b2300-8bc2-11eb-8eb0-0e694f1cc5e3.png)

### Verification

https://nextjs-wordpress-starter-jilfvgfuk-webdevstudios.vercel.app/team
- If setting above is set to "yes" for Team CPT, the `robots` meta tag should show `index, follow`; else, it should show `noindex, nofollow`.
