### PR TITLE
fix/294-gravity-forms

### DIFF
--- a/lib/wordpress/gravityForms/fieldProps.js
+++ b/lib/wordpress/gravityForms/fieldProps.js
@@ -3,7 +3,6 @@ export const globalFieldProps = `
   id
   adminLabel
   adminOnly
-  allowsPrepopulate
   conditionalLogic {
     rules {
       fieldId
@@ -16,7 +15,6 @@ export const globalFieldProps = `
   cssClassList
   label
   type
-  visibility
 `
 
 // Define Gravity Form field names and unique props.
@@ -40,6 +38,8 @@ export const fieldProps = {
     labelPlacement
     size
     subLabelPlacement
+    allowsPrepopulate
+    visibility
   `,
   CaptchaField: `
     captchaTheme
@@ -48,6 +48,8 @@ export const fieldProps = {
     simpleCaptchaBackgroundColor
     simpleCaptchaFontColor
     simpleCaptchaSize
+    allowsPrepopulate
+    visibility
   `,
   ChainedSelectField: `
     chainedSelectsAlignment
@@ -92,6 +94,8 @@ export const fieldProps = {
     }
     isRequired
     size
+    allowsPrepopulate
+    visibility
   `,
   CheckboxField: `
     checkboxChoices: choices {
@@ -111,6 +115,8 @@ export const fieldProps = {
     }
     isRequired
     size
+    allowsPrepopulate
+    visibility
   `,
   DateField: `
     calendarIconType
@@ -124,6 +130,8 @@ export const fieldProps = {
     noDuplicates
     placeholder
     size
+    allowsPrepopulate
+    visibility
   `,
   EmailField: `
     defaultValue
@@ -134,6 +142,8 @@ export const fieldProps = {
     noDuplicates
     placeholder
     size
+    allowsPrepopulate
+    visibility
   `,
   FileUploadField: `
     description
@@ -141,6 +151,8 @@ export const fieldProps = {
     inputName
     isRequired
     size
+    allowsPrepopulate
+    visibility
   `,
   HiddenField: `
     defaultValue
@@ -148,10 +160,14 @@ export const fieldProps = {
     isRequired
     noDuplicates
     size
+    allowsPrepopulate
+    visibility
   `,
   HtmlField: `
     content
     inputName
+    allowsPrepopulate
+    visibility
   `,
   ListField: `
     addIconUrl
@@ -169,6 +185,8 @@ export const fieldProps = {
     labelPlacement
     maxRows
     pageNumber
+    allowsPrepopulate
+    visibility
   `,
   MultiSelectField: `
     multiSelectChoices: choices {
@@ -183,6 +201,8 @@ export const fieldProps = {
     inputName
     isRequired
     size
+    allowsPrepopulate
+    visibility
   `,
   NameField: `
     allowsPrepopulate
@@ -199,6 +219,8 @@ export const fieldProps = {
     isRequired
     nameFormat
     size
+    allowsPrepopulate
+    visibility
   `,
   NumberField: `
     allowsPrepopulate
@@ -213,6 +235,8 @@ export const fieldProps = {
     rangeMax
     rangeMin
     size
+    allowsPrepopulate
+    visibility
   `,
   PageField: `
     allowsPrepopulate
@@ -246,10 +270,10 @@ export const fieldProps = {
       text
       type
     }
+    allowsPrepopulate
+    visibility
   `,
   PasswordField: `
-    allowsPrepopulate
-    passwordChoices: choices
     description
     errorMessage
     inputs {
@@ -274,6 +298,8 @@ export const fieldProps = {
     phoneFormat
     placeholder
     size
+    allowsPrepopulate
+    visibility
   `,
   PostCategoryField: `
     allowsPrepopulate
@@ -288,9 +314,10 @@ export const fieldProps = {
     inputName
     isRequired
     size
+    allowsPrepopulate
+    visibility
   `,
   PostContentField: `
-    allowsPrepopulate
     defaultValue
     description
     errorMessage
@@ -311,6 +338,8 @@ export const fieldProps = {
     placeholder
     postCustomFieldName
     size
+    allowsPrepopulate
+    visibility
   `,
   PostExcerptField: `
     allowsPrepopulate
@@ -321,6 +350,8 @@ export const fieldProps = {
     isRequired
     placeholder
     size
+    allowsPrepopulate
+    visibility
   `,
   PostImageField: `
     allowsPrepopulate
@@ -332,6 +363,8 @@ export const fieldProps = {
     inputName
     isRequired
     size
+    allowsPrepopulate
+    visibility
   `,
   PostTagsField: `
     allowsPrepopulate
@@ -342,6 +375,8 @@ export const fieldProps = {
     isRequired
     placeholder
     size
+    allowsPrepopulate
+    visibility
   `,
   PostTitleField: `
     allowsPrepopulate
@@ -352,6 +387,8 @@ export const fieldProps = {
     isRequired
     placeholder
     size
+    allowsPrepopulate
+    visibility
   `,
   RadioField: `
     allowsPrepopulate
@@ -368,13 +405,16 @@ export const fieldProps = {
     isRequired
     noDuplicates
     size
+    allowsPrepopulate
+    visibility
   `,
   SectionField: `
     allowsPrepopulate
     description
+    allowsPrepopulate
+    visibility
   `,
   SignatureField: `
-    allowsPrepopulate
     backgroundColor
     borderColor
     borderStyle
@@ -402,6 +442,8 @@ export const fieldProps = {
     noDuplicates
     placeholder
     size
+    allowsPrepopulate
+    visibility
   `,
   TextAreaField: `
     allowsPrepopulate
@@ -414,6 +456,8 @@ export const fieldProps = {
     noDuplicates
     placeholder
     size
+    allowsPrepopulate
+    visibility
   `,
   TextField: `
     allowsPrepopulate
@@ -427,6 +471,8 @@ export const fieldProps = {
     noDuplicates
     placeholder
     size
+    allowsPrepopulate
+    visibility
   `,
   TimeField: `
     allowsPrepopulate
@@ -436,6 +482,8 @@ export const fieldProps = {
     isRequired
     noDuplicates
     size
+    allowsPrepopulate
+    visibility
   `,
   WebsiteField: `
     allowsPrepopulate


### PR DESCRIPTION
Closes #294  

### Link

https://nextjs-wordpress-starter-n56k3k691-webdevstudios.vercel.app/

### Description

Removes deprecated GF GraphQL fields to allow forms to display on FE.

### Screenshot

![Screen Shot 2021-03-23 at 11 13 44 AM](https://user-images.githubusercontent.com/36422618/112189018-317e9a00-8bc9-11eb-82f1-7d9736fb2b2b.png)

### Verification

https://nextjs-wordpress-starter-n56k3k691-webdevstudios.vercel.app/contact
- Contact Us form should display
