### PR TITLE
Feature/293 dynamic archive meta title

### DIFF
--- a/functions/formatArchiveSeoData.js
+++ b/functions/formatArchiveSeoData.js
@@ -1,0 +1,40 @@
+import {postTypes} from '@lib/wordpress/_global/postTypes'
+
+/**
+ * Format archive SEO data.
+ *
+ * @author WebDevStudios
+ * @param {string} postType     WP post type.
+ * @param {object} postsPageSeo WP posts page SEO data.
+ * @param {object} defaultSeo   Formatted default SEO data.
+ * @param {object} fallbackSeo  Fallback (hard-coded) archive SEO data.
+ * @param {object} archiveSeo   Dynamic archive SEO data.
+ * @return {object}             Formatted archive SEO data.
+ */
+export default function formatArchiveSeoData(
+  postType,
+  postsPageSeo,
+  defaultSeo,
+  fallbackSeo,
+  archiveSeo
+) {
+  // Check if viewing post archive and have received posts page SEO data.
+  if ('post' === postType && postsPageSeo) {
+    return {
+      ...postsPageSeo,
+      canonical: `${defaultSeo?.openGraph?.url ?? ''}/${
+        postTypes?.[postType]?.route
+      }`
+    }
+  }
+
+  // Use archive SEO if provided, else generate SEO data from fallback data.
+  return {
+    title:
+      archiveSeo?.title ??
+      `${fallbackSeo?.title} - ${defaultSeo?.openGraph?.siteName ?? ''}`,
+    metaDesc: archiveSeo?.metaDesc ?? fallbackSeo?.description ?? '',
+    metaRobotsNofollow: archiveSeo?.metaRobotsNofollow ?? 'follow',
+    metaRobotsNoindex: archiveSeo?.metaRobotsNoindex ?? 'index'
+  }
+}

--- a/functions/formatArchiveSeoData.js
+++ b/functions/formatArchiveSeoData.js
@@ -35,6 +35,9 @@ export default function formatArchiveSeoData(
       `${fallbackSeo?.title} - ${defaultSeo?.openGraph?.siteName ?? ''}`,
     metaDesc: archiveSeo?.metaDesc ?? fallbackSeo?.description ?? '',
     metaRobotsNofollow: archiveSeo?.metaRobotsNofollow ?? 'follow',
-    metaRobotsNoindex: archiveSeo?.metaRobotsNoindex ?? 'index'
+    metaRobotsNoindex: archiveSeo?.metaRobotsNoindex ?? 'index',
+    canonical:
+      archiveSeo?.canonical ??
+      `${defaultSeo?.openGraph?.url ?? ''}/${fallbackSeo?.route}`
   }
 }

--- a/functions/formatArchiveSeoData.js
+++ b/functions/formatArchiveSeoData.js
@@ -1,4 +1,4 @@
-import {postTypes} from '@lib/wordpress/_global/postTypes'
+import {postTypes} from '@/lib/wordpress/_global/postTypes'
 
 /**
  * Format archive SEO data.

--- a/lib/wordpress/_global/getPostTypeArchive.js
+++ b/lib/wordpress/_global/getPostTypeArchive.js
@@ -1,3 +1,4 @@
+import formatArchiveSeoData from '@/functions/formatArchiveSeoData'
 import formatDefaultSeoData from '@/functions/formatDefaultSeoData'
 import {initializeWpApollo} from '../connector'
 import getMenus from '../menus/getMenus'
@@ -107,33 +108,13 @@ export default async function getPostTypeArchive(
 
       // Attempt to use posts page for blog, default to custom SEO.
       response.post = {
-        seo:
-          'post' === postType && homepageSettings?.postsPage?.seo
-            ? {
-                ...homepageSettings.postsPage.seo,
-                canonical: `${response.defaultSeo?.openGraph?.url ?? ''}/${
-                  postTypes?.[postType]?.route
-                }`
-              }
-            : {
-                title: `${archiveQuerySeo?.[postType]?.title} - ${
-                  response.defaultSeo?.openGraph?.siteName ?? ''
-                }`,
-                metaDesc: archiveQuerySeo?.[postType]?.description,
-                canonical: `${response.defaultSeo?.openGraph?.url ?? ''}/${
-                  postTypes?.[postType]?.route
-                }`,
-                metaRobotsNofollow:
-                  true ===
-                  seo?.contentTypes?.[postType]?.archive?.metaRobotsNoindex
-                    ? 'nofollow'
-                    : 'follow',
-                metaRobotsNoindex:
-                  true ===
-                  seo?.contentTypes?.[postType]?.archive?.metaRobotsNoindex
-                    ? 'noindex'
-                    : 'index'
-              }
+        seo: formatArchiveSeoData(
+          postType,
+          homepageSettings?.postsPage?.seo,
+          response.defaultSeo,
+          archiveQuerySeo?.[postType],
+          data?.archiveSeo
+        )
       }
 
       // Extract pagination data.

--- a/lib/wordpress/_partials/archiveData.js
+++ b/lib/wordpress/_partials/archiveData.js
@@ -1,0 +1,10 @@
+import archivePageInfo from './archivePageInfo'
+
+/**
+ * Query partial: retrieve default data for archives.
+ */
+const archiveData = `
+ ${archivePageInfo}
+`
+
+export default archiveData

--- a/lib/wordpress/_partials/archiveData.js
+++ b/lib/wordpress/_partials/archiveData.js
@@ -2,7 +2,7 @@ import archivePageInfo from './archivePageInfo'
 
 // Query partial: retrieve default data for archives.
 const archiveData = `
- ${archivePageInfo}
+  ${archivePageInfo}
 `
 
 export default archiveData

--- a/lib/wordpress/_partials/archiveData.js
+++ b/lib/wordpress/_partials/archiveData.js
@@ -1,8 +1,6 @@
 import archivePageInfo from './archivePageInfo'
 
-/**
- * Query partial: retrieve default data for archives.
- */
+// Query partial: retrieve default data for archives.
 const archiveData = `
  ${archivePageInfo}
 `

--- a/lib/wordpress/_partials/archiveData.js
+++ b/lib/wordpress/_partials/archiveData.js
@@ -1,8 +1,10 @@
 import archivePageInfo from './archivePageInfo'
+import archiveSeo from './archiveSeo'
 
 // Query partial: retrieve default data for archives.
 const archiveData = `
   ${archivePageInfo}
+  ${archiveSeo}
 `
 
 export default archiveData

--- a/lib/wordpress/_partials/archivePageInfo.js
+++ b/lib/wordpress/_partials/archivePageInfo.js
@@ -1,6 +1,4 @@
-/**
- * Query partial: retrieve pagination info for archive.
- */
+// Query partial: retrieve pagination info for archive.
 const archivePageInfo = `
   pageInfo {
     startCursor

--- a/lib/wordpress/_partials/archiveSeo.js
+++ b/lib/wordpress/_partials/archiveSeo.js
@@ -1,6 +1,7 @@
 // Query partial: retrieve archive SEO data.
 const archiveSeo = `
   archiveSeo {
+    canonical
     metaDesc
     metaRobotsNofollow
     metaRobotsNoindex

--- a/lib/wordpress/_partials/archiveSeo.js
+++ b/lib/wordpress/_partials/archiveSeo.js
@@ -1,0 +1,11 @@
+// Query partial: retrieve archive SEO data.
+const archiveSeo = `
+  archiveSeo {
+    metaDesc
+    metaRobotsNofollow
+    metaRobotsNoindex
+    title
+  }
+`
+
+export default archiveSeo

--- a/lib/wordpress/_partials/defaultPageData.js
+++ b/lib/wordpress/_partials/defaultPageData.js
@@ -1,9 +1,7 @@
-import defaultSeoFields from './defaultSeoFields'
 import allMenus from './allMenus'
+import defaultSeoFields from './defaultSeoFields'
 
-/**
- * Query partial: retrieve default data for all frontend pages.
- */
+// Query partial: retrieve default data for all frontend pages.
 const defaultPageData = `
   ${defaultSeoFields}
   ${allMenus}

--- a/lib/wordpress/_partials/defaultSeoFields.js
+++ b/lib/wordpress/_partials/defaultSeoFields.js
@@ -2,49 +2,49 @@ import seoPostFields from './seoPostFields'
 
 // Query partial: retrieve homepage & site SEO fields.
 const defaultSeoFields = `
-homepageSettings {
-  frontPage {
-    ${seoPostFields}
-  }
-}
-siteSeo: seo {
-  schema {
-    siteName
-    siteUrl
-  }
-  openGraph {
-    defaultImage {
-      altText
-      sourceUrl(size: THUMBNAIL)
+  homepageSettings {
+    frontPage {
+      ${seoPostFields}
     }
   }
-  social {
-    facebook {
-      url
+  siteSeo: seo {
+    schema {
+      siteName
+      siteUrl
     }
-    instagram {
-      url
+    openGraph {
+      defaultImage {
+        altText
+        sourceUrl(size: THUMBNAIL)
+      }
     }
-    linkedIn {
-      url
-    }
-    mySpace {
-      url
-    }
-    pinterest {
-      url
-    }
-    twitter {
-      username
-    }
-    wikipedia {
-      url
-    }
-    youTube {
-      url
+    social {
+      facebook {
+        url
+      }
+      instagram {
+        url
+      }
+      linkedIn {
+        url
+      }
+      mySpace {
+        url
+      }
+      pinterest {
+        url
+      }
+      twitter {
+        username
+      }
+      wikipedia {
+        url
+      }
+      youTube {
+        url
+      }
     }
   }
-}
 `
 
 export default defaultSeoFields

--- a/lib/wordpress/teams/queryTeamsArchive.js
+++ b/lib/wordpress/teams/queryTeamsArchive.js
@@ -25,15 +25,6 @@ const queryTeamsArchive = gql`
     $imageSize: MediaItemSizeEnum = THUMBNAIL
   ) {
     ${defaultPageData}
-    seo {
-      contentTypes {
-        team {
-          archive {
-            metaRobotsNoindex
-          }
-        }
-      }
-    }
     teams(
       first: $first
       last: $last

--- a/lib/wordpress/teams/queryTeamsArchive.js
+++ b/lib/wordpress/teams/queryTeamsArchive.js
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client'
-import archivePageInfo from '../_partials/archivePageInfo'
+import archiveData from '../_partials/archiveData'
 import defaultPageData from '../_partials/defaultPageData'
 import featuredImagePostFields from '../_partials/featuredImagePostFields'
 import globalPostFields from '../_partials/globalPostFields'
@@ -41,7 +41,7 @@ const queryTeamsArchive = gql`
       before: $before
       where: {orderby: {field: $orderBy, order: $order}}
     ) {
-      ${archivePageInfo}
+      ${archiveData}
       edges {
         node {
           ...ArchiveTeamFields


### PR DESCRIPTION
Closes #293 
(Requires https://github.com/WebDevStudios/nextjs-starter-wordpress/pull/21 to be merged first)

### Link

https://nextjs-wordpress-starter-rkb3s6vlg-webdevstudios.vercel.app/

### Description

Adds archive data and archive SEO query partials, utilizing new `archiveSEO` fields.
Updates Team CPT archive query to use new archive data query partial.
Adds archive SEO formatter function and adds call to `getPostTypeArchive()`.
Fixes some minor formatting issues in the `/partials` dir to make things more consistent.

### Screenshot

![Screen Shot 2021-03-31 at 11 55 26 AM](https://user-images.githubusercontent.com/36422618/113189667-acbefc00-9218-11eb-9d24-45cb79096d9c.png)

### Verification

https://nextjs-wordpress-starter-rkb3s6vlg-webdevstudios.vercel.app/team
- Browser tab title and title meta tags in `<head>` should match format from WP admin > SEO > Search Appearance > Team Members > Settings for Team Members archive > SEO title
- Robots meta tags should reflect settings in "Show the archive for Team Members in search results?"
- Description meta tags should match CPT archive meta description setting
- Canonical URL should be accurate
