### PR TITLE
#356 - Fix 404 slug

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -46,7 +46,7 @@ export default function Custom404({post}) {
  * @return {object} Post props.
  */
 export async function getStaticProps() {
-  return await getPostTypeStaticProps({slug: '404-not-found'}, postType)
+  return await getPostTypeStaticProps({slug: '404'}, postType)
 }
 
 Custom404.propTypes = {


### PR DESCRIPTION
Closes #356 

### Link
N/A

### Description
- Change 404 slug to just `404` instead of `404-not-found`

### Screenshot
<img width="1440" alt="Screen Shot 2021-04-14 at 12 35 34 AM" src="https://user-images.githubusercontent.com/1948204/114593818-1c27f780-9cbf-11eb-9528-aa84bc9b1db6.png">



### Verification
 - Run `npm run dev` to verify that there is no `Error: The /404 page can not return notFound in "getStaticProps"`
