### PR TITLE
Bump next-auth to v3.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1945,6 +1945,24 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@next-auth/prisma-legacy-adapter": {
+      "version": "0.0.1-canary.127",
+      "resolved": "https://registry.npmjs.org/@next-auth/prisma-legacy-adapter/-/prisma-legacy-adapter-0.0.1-canary.127.tgz",
+      "integrity": "sha512-Pd2Y8b1ibDywrndbj3751VNKv1mVcg2w0uNIi01EBVkm5pqA1X+VnKWbPeHfh4arLYw93RPCvfLbWBZS7J1gZQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0"
+      }
+    },
+    "@next-auth/typeorm-legacy-adapter": {
+      "version": "0.0.2-canary.129",
+      "resolved": "https://registry.npmjs.org/@next-auth/typeorm-legacy-adapter/-/typeorm-legacy-adapter-0.0.2-canary.129.tgz",
+      "integrity": "sha512-xEGz3TzBzz+5nXQ6BnC++KGfxTOAgztL32ZRLq47UKz9M0kFBP6pCMJjTszltsBHYUI/Wac2IG2egMTpHtppiQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "require_optional": "^1.0.1",
+        "typeorm": "^0.2.30"
+      }
+    },
     "@next/bundle-analyzer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-10.2.0.tgz",
@@ -7153,11 +7171,6 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
-    },
-    "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "css-blank-pseudo": {
       "version": "0.1.4",
@@ -13401,14 +13414,13 @@
       }
     },
     "next-auth": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-3.21.0.tgz",
-      "integrity": "sha512-x5liry5HHa91/KaJZYHaYdYCQB76OWtuGnCyJeobSLjoXGeu/CQucTgWUGh3y8h4B+WTSlufM2LipambYnPu1g==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-3.21.1.tgz",
+      "integrity": "sha512-bCtW85rndUG8mt4Paip/BRxC4ZmA+V1Slta9ojh94dzylnYaPHXQrwtlZSl9asM5VKRAKC9Y3m+Q+VLqPDLVLA==",
       "requires": {
         "@babel/runtime": "^7.14.0",
         "@next-auth/prisma-legacy-adapter": "^0.0.1-canary.127",
         "@next-auth/typeorm-legacy-adapter": "^0.0.2-canary.129",
-        "crypto-js": "^4.0.0",
         "futoin-hkdf": "^1.3.2",
         "jose": "^1.27.2",
         "jsonwebtoken": "^8.5.1",
@@ -13417,29 +13429,7 @@
         "pkce-challenge": "^2.1.0",
         "preact": "^10.4.1",
         "preact-render-to-string": "^5.1.14",
-        "querystring": "^0.2.0",
-        "require_optional": "^1.0.1",
-        "typeorm": "^0.2.30"
-      },
-      "dependencies": {
-        "@next-auth/prisma-legacy-adapter": {
-          "version": "0.0.1-canary.127",
-          "resolved": "https://registry.npmjs.org/@next-auth/prisma-legacy-adapter/-/prisma-legacy-adapter-0.0.1-canary.127.tgz",
-          "integrity": "sha512-Pd2Y8b1ibDywrndbj3751VNKv1mVcg2w0uNIi01EBVkm5pqA1X+VnKWbPeHfh4arLYw93RPCvfLbWBZS7J1gZQ==",
-          "requires": {
-            "@babel/runtime": "^7.14.0"
-          }
-        },
-        "@next-auth/typeorm-legacy-adapter": {
-          "version": "0.0.2-canary.129",
-          "resolved": "https://registry.npmjs.org/@next-auth/typeorm-legacy-adapter/-/typeorm-legacy-adapter-0.0.2-canary.129.tgz",
-          "integrity": "sha512-xEGz3TzBzz+5nXQ6BnC++KGfxTOAgztL32ZRLq47UKz9M0kFBP6pCMJjTszltsBHYUI/Wac2IG2egMTpHtppiQ==",
-          "requires": {
-            "@babel/runtime": "^7.14.0",
-            "require_optional": "^1.0.1",
-            "typeorm": "^0.2.30"
-          }
-        }
+        "querystring": "^0.2.0"
       }
     },
     "next-seo": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "next": "latest",
-    "next-auth": "^3.21.0",
+    "next-auth": "^3.21.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },


### PR DESCRIPTION
### Description

Bumps next-auth to v3.21.1 to fix Adapter errors, e.g.,
```
TypeError: Cannot read property 'Adapter' of undefined
```

### Verification

1. Login/profile/logout/register should work as exptected
