### PR TITLE
feature/410-expand-block-attrs

### DIFF
--- a/components/atoms/Code/Code.js
+++ b/components/atoms/Code/Code.js
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import {Prism as SyntaxHighlighter} from 'react-syntax-highlighter'
@@ -15,8 +16,10 @@ import styles from './Code.module.css'
  * @return {Element}                 The Code component.
  */
 export default function Code({id, className, content}) {
-  // Use the className to pass the langauge.
-  const language = className ? className : 'javascript'
+  const classNames = className.length ? className.split(' ') : []
+
+  // Use the first entry in className to pass the langauge.
+  const language = classNames.length ? classNames.shift() : 'javascript'
 
   /**
    * Replace any `&lt;` and `&gt; encoded HTML.
@@ -36,7 +39,10 @@ export default function Code({id, className, content}) {
   return (
     <>
       {!!content && (
-        <div id={id ? id : null} className={styles.code}>
+        <div
+          id={id ? id : null}
+          className={cn(styles.code, classNames.join(' '))}
+        >
           <SyntaxHighlighter style={tomorrow} language={language}>
             {codeFormatter(content)}
           </SyntaxHighlighter>

--- a/components/atoms/Code/Code.js
+++ b/components/atoms/Code/Code.js
@@ -16,10 +16,10 @@ import styles from './Code.module.css'
  * @return {Element}                 The Code component.
  */
 export default function Code({id, className, content}) {
-  const classNames = className.length ? className.split(' ') : []
+  const classNames = className?.length ? className.split(' ') : []
 
   // Use the first entry in className to pass the langauge.
-  const language = classNames.length ? classNames.shift() : 'javascript'
+  const language = classNames?.length ? classNames.shift() : 'javascript'
 
   /**
    * Replace any `&lt;` and `&gt; encoded HTML.

--- a/components/atoms/Code/Code.stories.mdx
+++ b/components/atoms/Code/Code.stories.mdx
@@ -28,7 +28,7 @@ export const Template = (args) => <Code {...args} />
   <Story
     name="Controls"
     args={{
-      id: 'my-code-block'
+      id: 'my-code-block',
       content: '<p>this is a code block!</p>',
       className: 'html custom-class'
     }}

--- a/components/atoms/Code/Code.stories.mdx
+++ b/components/atoms/Code/Code.stories.mdx
@@ -10,7 +10,11 @@ Use this component to display a code block.
 
 <Canvas>
   <Story name="Component">
-    <Code content="<p>this is a code block!</p>" />
+    <Code
+      id="my-code-block"
+      content="<p>this is a code block!</p>"
+      className="html custom-class"
+    />
   </Story>
 </Canvas>
 
@@ -24,8 +28,9 @@ export const Template = (args) => <Code {...args} />
   <Story
     name="Controls"
     args={{
+      id: 'my-code-block'
       content: '<p>this is a code block!</p>',
-      className: 'html'
+      className: 'html custom-class'
     }}
   >
     {Template.bind({})}

--- a/components/atoms/Code/Code.stories.mdx
+++ b/components/atoms/Code/Code.stories.mdx
@@ -11,7 +11,6 @@ Use this component to display a code block.
 <Canvas>
   <Story name="Component">
     <Code
-      id="my-code-block"
       content="<p>this is a code block!</p>"
       className="html custom-class"
     />
@@ -28,7 +27,6 @@ export const Template = (args) => <Code {...args} />
   <Story
     name="Controls"
     args={{
-      id: 'my-code-block',
       content: '<p>this is a code block!</p>',
       className: 'html custom-class'
     }}

--- a/components/atoms/Separator/Separator.js
+++ b/components/atoms/Separator/Separator.js
@@ -8,23 +8,25 @@ import styles from './Separator.module.css'
  *
  * @author WebDevStudios
  * @param  {object}  props           The component properties.
+ * @param  {string}  props.anchor    Optional anchor/id.
  * @param  {string}  props.className Optional classname.
  * @param  {boolean} props.fullWidth Is this a fullwidth block.
  * @return {Element}                 The Separator component.
  */
-export default function Separator({className, fullWidth}) {
+export default function Separator({anchor, className, fullWidth}) {
   return (
     <>
       {fullWidth ? (
-        <hr className={cn(styles.separator, className)} />
+        <hr id={anchor} className={cn(styles.separator, className)} />
       ) : (
-        <hr className={cn(styles.separator, className)} />
+        <hr id={anchor} className={cn(styles.separator, className)} />
       )}
     </>
   )
 }
 
 Separator.propTypes = {
+  anchor: PropTypes.string,
   className: PropTypes.string,
   fullWidth: PropTypes.bool.isRequired
 }

--- a/components/atoms/Separator/Separator.stories.mdx
+++ b/components/atoms/Separator/Separator.stories.mdx
@@ -20,7 +20,7 @@ The default separator is equal to the container width. To get a full width separ
 
 <Canvas>
   <Story name="Full Width">
-    <Separator fullWidth />
+    <Separator anchor="my-separator" className="custom-separator" fullWidth />
   </Story>
 </Canvas>
 
@@ -34,6 +34,8 @@ export const Template = (args) => <Separator {...args} />
   <Story
     name="Controls"
     args={{
+      anchor: 'my-separator',
+      className: 'custom-separator',
       fullWidth: false
     }}
   >

--- a/components/atoms/Separator/Separator.stories.mdx
+++ b/components/atoms/Separator/Separator.stories.mdx
@@ -20,7 +20,7 @@ The default separator is equal to the container width. To get a full width separ
 
 <Canvas>
   <Story name="Full Width">
-    <Separator anchor="my-separator" className="custom-separator" fullWidth />
+    <Separator fullWidth />
   </Story>
 </Canvas>
 
@@ -34,8 +34,6 @@ export const Template = (args) => <Separator {...args} />
   <Story
     name="Controls"
     args={{
-      anchor: 'my-separator',
-      className: 'custom-separator',
       fullWidth: false
     }}
   >

--- a/components/blocks/Gutenberg/BlockColumns/BlockColumns.js
+++ b/components/blocks/Gutenberg/BlockColumns/BlockColumns.js
@@ -9,17 +9,17 @@ import PropTypes from 'prop-types'
  *
  * @author WebDevStudios
  * @param  {object}  props             The component properties.
- * @param  {object}  props.options     Option props object.
+ * @param  {object}  props.columns     Option props object.
  * @param  {object}  props.innerBlocks The array of inner blocks to display.
  * @return {Element}                   The Columns component.
  */
-export default function BlockColumns({options, innerBlocks}) {
+export default function BlockColumns({columns, innerBlocks}) {
   return (
     <>
       {!!innerBlocks?.length && (
         <Columns
-          id={options?.anchor}
-          className={options?.className}
+          id={columns?.anchor}
+          className={columns?.className}
           columnCount={innerBlocks?.length}
         >
           {innerBlocks.map((block, index) => {
@@ -42,7 +42,7 @@ export default function BlockColumns({options, innerBlocks}) {
 }
 
 BlockColumns.propTypes = {
-  options: PropTypes.shape({
+  columns: PropTypes.shape({
     anchor: PropTypes.string,
     className: PropTypes.string
   }),

--- a/components/blocks/Gutenberg/BlockColumns/BlockColumns.js
+++ b/components/blocks/Gutenberg/BlockColumns/BlockColumns.js
@@ -24,7 +24,11 @@ export default function BlockColumns({options, innerBlocks}) {
         >
           {innerBlocks.map((block, index) => {
             return (
-              <div key={`column-${index}`}>
+              <div
+                key={`column-${index}`}
+                id={block?.attributes?.anchor}
+                className={block?.attributes?.className}
+              >
                 {!!block?.innerBlocks?.length && (
                   <Blocks blocks={block.innerBlocks} />
                 )}

--- a/components/blocks/Gutenberg/BlockCover/BlockCover.js
+++ b/components/blocks/Gutenberg/BlockCover/BlockCover.js
@@ -17,7 +17,11 @@ export default function BlockCover({media, innerBlocks}) {
   return (
     <>
       {!!media?.url && (
-        <Hero backgroundImage={media} id={media?.anchor}>
+        <Hero
+          backgroundImage={media}
+          id={media?.anchor}
+          className={media?.className}
+        >
           {!!innerBlocks?.length && <Blocks blocks={innerBlocks} />}
         </Hero>
       )}
@@ -28,6 +32,7 @@ export default function BlockCover({media, innerBlocks}) {
 BlockCover.propTypes = {
   media: PropTypes.shape({
     anchor: PropTypes.string,
+    className: PropTypes.string,
     url: PropTypes.string
   }),
   innerBlocks: PropTypes.arrayOf(

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -18,6 +18,7 @@ export default function BlockMediaText({media, innerBlocks}) {
     <>
       {!!media && innerBlocks?.length && (
         <MediaText
+          id={media?.anchor}
           className={media?.className}
           mediaLeft={media?.mediaPosition === 'left' ? true : false}
           image={{url: media?.mediaUrl, alt: media?.mediaAlt}}

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -18,6 +18,7 @@ export default function BlockMediaText({media, innerBlocks}) {
     <>
       {!!media && innerBlocks?.length && (
         <MediaText
+          className={media?.className}
           mediaLeft={media?.mediaPosition === 'left' ? true : false}
           image={{url: media?.mediaUrl, alt: media?.mediaAlt}}
         >

--- a/components/organisms/Hero/Hero.js
+++ b/components/organisms/Hero/Hero.js
@@ -14,6 +14,7 @@ import styles from './Hero.module.css'
  * @param  {any}     props.children        InnerBlocks.
  * @param  {object}  props.ctaText         The cta text.
  * @param  {object}  props.ctaUrl          The cta url.
+ * @param  {string}  props.id              Optional element ID.
  * @param  {string}  props.subtitle        Text for the subtitle.
  * @param  {string}  props.title           Text for the title.
  * @return {Element}                       The Hero component.
@@ -25,11 +26,13 @@ export default function Hero({
   children,
   ctaText,
   ctaUrl,
+  id,
   subtitle,
   title
 }) {
   return (
     <section
+      id={id}
       className={cn(styles.hero, className)}
       style={{
         // These css custom properties are used inside the css module file to set the card's background image, tint overlay, and fallback bg color.
@@ -65,6 +68,7 @@ Hero.propTypes = {
   children: PropTypes.any,
   ctaText: PropTypes.string,
   ctaUrl: PropTypes.string,
+  id: PropTypes.string,
   subtitle: PropTypes.string,
   title: PropTypes.string
 }

--- a/components/organisms/Hero/Hero.stories.mdx
+++ b/components/organisms/Hero/Hero.stories.mdx
@@ -10,12 +10,13 @@ Use this to display a large CTA, usually at the top of a page.
 <Canvas>
   <Story name="Component">
     <Hero
+      id="my-hero-component"
+      className="custom-hero-component"
       subtitle="Check it out"
       title="New Designs"
       body="Our amazing new design is here! Get it while it's hot, it won't be hot for long... uh oh, already cooling."
       backgroundImage={{
-        url:
-          'https://images.unsplash.com/photo-1610991149688-c1321006bcc1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1110&q=60'
+        url: 'https://images.unsplash.com/photo-1610991149688-c1321006bcc1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1110&q=60'
       }}
       cta={{icon: 'arrowRight', text: 'Take a look'}}
     />

--- a/components/organisms/Hero/Hero.stories.mdx
+++ b/components/organisms/Hero/Hero.stories.mdx
@@ -10,8 +10,6 @@ Use this to display a large CTA, usually at the top of a page.
 <Canvas>
   <Story name="Component">
     <Hero
-      id="my-hero-component"
-      className="custom-hero-component"
       subtitle="Check it out"
       title="New Designs"
       body="Our amazing new design is here! Get it while it's hot, it won't be hot for long... uh oh, already cooling."

--- a/components/organisms/MediaText/MediaText.js
+++ b/components/organisms/MediaText/MediaText.js
@@ -13,6 +13,7 @@ import styles from './MediaText.module.css'
  * @param  {Element} props.children  The child elements.
  * @param  {string}  props.className The className.
  * @param  {object}  props.cta       The cta object with text and url strings.
+ * @param  {string}  props.id        Optional element ID.
  * @param  {object}  props.image     The image object with url and alt text.
  * @param  {boolean} props.mediaLeft Whether to show media on the left of the text.
  * @param  {string}  props.title     The title.
@@ -23,6 +24,7 @@ export default function MediaText({
   children,
   className,
   cta,
+  id,
   image,
   mediaLeft,
   title
@@ -37,6 +39,7 @@ export default function MediaText({
 
   return (
     <section
+      id={id}
       className={cn(
         styles.mediaText,
         mediaLeft ? styles.mediaLeft : null,
@@ -86,6 +89,7 @@ MediaText.propTypes = {
     url: PropTypes.string,
     icon: PropTypes.string
   }),
+  id: PropTypes.string,
   image: PropTypes.shape({
     url: PropTypes.string,
     alt: PropTypes.string

--- a/components/organisms/MediaText/MediaText.stories.mdx
+++ b/components/organisms/MediaText/MediaText.stories.mdx
@@ -10,11 +10,11 @@ Use this to display media and text in a 50/50 layout.
 <Canvas>
   <Story name="Component">
     <MediaText
+      id="media-text"
       title="New Designs"
       body="Our amazing new design is here! Get it while it's hot, it won't be hot for long... uh oh, already cooling."
       image={{
-        url:
-          'https://images.unsplash.com/photo-1610991149688-c1321006bcc1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1110&q=60',
+        url: 'https://images.unsplash.com/photo-1610991149688-c1321006bcc1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1110&q=60',
         alt: 'Some alt text'
       }}
       cta={{icon: 'arrowRight', text: 'Take a look'}}
@@ -29,11 +29,11 @@ Media will display on the right on large screens by default. Use the `mediaLeft`
 <Canvas>
   <Story name="MediaLeft">
     <MediaText
+      id="media-text"
       title="New Designs"
       body="Our amazing new design is here! Get it while it's hot, it won't be hot for long... uh oh, already cooling."
       image={{
-        url:
-          'https://images.unsplash.com/photo-1610991149688-c1321006bcc1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1110&q=60',
+        url: 'https://images.unsplash.com/photo-1610991149688-c1321006bcc1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1110&q=60',
         alt: 'Some alt text'
       }}
       cta={{icon: 'arrowRight', text: 'Take a look'}}
@@ -49,14 +49,14 @@ You can display children as an element using the `children` prop. If used, the `
 <Canvas>
   <Story name="Children">
     <MediaText
+      id="media-text"
       children={
         <div>
           <p>Hi I'm a child element!</p>
         </div>
       }
       image={{
-        url:
-          'https://images.unsplash.com/photo-1610991149688-c1321006bcc1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1110&q=60',
+        url: 'https://images.unsplash.com/photo-1610991149688-c1321006bcc1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1110&q=60',
         alt: 'Some alt text'
       }}
       mediaLeft

--- a/components/organisms/MediaText/MediaText.stories.mdx
+++ b/components/organisms/MediaText/MediaText.stories.mdx
@@ -10,7 +10,6 @@ Use this to display media and text in a 50/50 layout.
 <Canvas>
   <Story name="Component">
     <MediaText
-      id="media-text"
       title="New Designs"
       body="Our amazing new design is here! Get it while it's hot, it won't be hot for long... uh oh, already cooling."
       image={{
@@ -29,7 +28,6 @@ Media will display on the right on large screens by default. Use the `mediaLeft`
 <Canvas>
   <Story name="MediaLeft">
     <MediaText
-      id="media-text"
       title="New Designs"
       body="Our amazing new design is here! Get it while it's hot, it won't be hot for long... uh oh, already cooling."
       image={{
@@ -49,7 +47,6 @@ You can display children as an element using the `children` prop. If used, the `
 <Canvas>
   <Story name="Children">
     <MediaText
-      id="media-text"
       children={
         <div>
           <p>Hi I'm a child element!</p>


### PR DESCRIPTION
References #410
Closes #470

### Description

Expands WP core block attribute support:
- Code: adds support for multiple class names to be passed (first is used as language, rest are passed as `className`)
- Media & Text: adds support for class and anchor
- Columns: adds support for class and anchor on outer Columns and inner Column
- Cover: adds support for class and anchor
- Separator: adds support for anchor

### Screenshot

![Screen Shot 2021-05-28 at 2 51 40 PM](https://user-images.githubusercontent.com/36422618/120040705-478f4900-bfc4-11eb-869b-fc89d4fc66fd.png)

![Screen Shot 2021-05-28 at 3 21 55 PM](https://user-images.githubusercontent.com/36422618/120043027-74455f80-bfc8-11eb-814c-59e30c7bc9ca.png)

![Screen Shot 2021-05-28 at 3 23 30 PM](https://user-images.githubusercontent.com/36422618/120043158-ad7dcf80-bfc8-11eb-84be-60090ca454aa.png)

![Screen Shot 2021-05-28 at 3 27 34 PM](https://user-images.githubusercontent.com/36422618/120043457-414f9b80-bfc9-11eb-92c4-9c8cf0259297.png)

![Screen Shot 2021-05-28 at 3 29 30 PM](https://user-images.githubusercontent.com/36422618/120043623-870c6400-bfc9-11eb-9a8c-66935fbe5a2e.png)

### Verification

https://nextjs-wordpress-starter-clmxb3scz-webdevstudios.vercel.app/blog/410-anchor-classname-testing
- ensure all blocks above display anchor/id
