### PR TITLE
Feature/410 button block

### DIFF
--- a/components/atoms/Button/Button.js
+++ b/components/atoms/Button/Button.js
@@ -32,23 +32,24 @@ ButtonInner.propTypes = {
 }
 
 /**
- * @param  {object}   props             The props object.
- * @param  {string}   props.attributes  Optional attributes to add to the button.
- * @param  {string}   props.className   Optional classNames.
- * @param  {boolean}  props.disabled    Whether the button is disabled.
- * @param  {boolean}  props.fluid       Whether the button should be full width.
- * @param  {string}   props.icon        Icon to render inside the button.
- * @param  {boolean}  props.iconOnly    Whether this button should render as an icon only button.
- * @param  {string}   props.iconLeft    Whether to render the icon on the left.
- * @param  {Function} props.onClick     Button onClick function.
- * @param  {string}   props.size        Button size.
- * @param  {object}   props.style       Custom button styles.
- * @param  {string}   props.tag         The wrapper tag.
- * @param  {string}   props.text        Button text.
- * @param  {string}   props.type        Button type.
- * @param  {string}   props.url         Button link url.
- * @param  {boolean}  props.urlExternal Whether the url on this button links to an external site.
- * @return {Element}                    The button component.
+ * @param  {object}   props              The props object.
+ * @param  {string}   props.attributes   Optional attributes to add to the button.
+ * @param  {string}   props.className    Optional classNames.
+ * @param  {boolean}  props.disabled     Whether the button is disabled.
+ * @param  {boolean}  props.fluid        Whether the button should be full width.
+ * @param  {string}   props.icon         Icon to render inside the button.
+ * @param  {boolean}  props.iconOnly     Whether this button should render as an icon only button.
+ * @param  {string}   props.iconLeft     Whether to render the icon on the left.
+ * @param  {Function} props.onClick      Button onClick function.
+ * @param  {string}   props.size         Button size.
+ * @param  {object}   props.style        Custom button styles.
+ * @param  {boolean}  props.styleOutline Whether this button has the outline style.
+ * @param  {string}   props.tag          The wrapper tag.
+ * @param  {string}   props.text         Button text.
+ * @param  {string}   props.type         Button type.
+ * @param  {string}   props.url          Button link url.
+ * @param  {boolean}  props.urlExternal  Whether the url on this button links to an external site.
+ * @return {Element}                     The button component.
  */
 export default function Button({
   attributes,
@@ -61,6 +62,7 @@ export default function Button({
   onClick,
   size,
   style,
+  styleOutline,
   tag,
   text,
   type,
@@ -75,7 +77,8 @@ export default function Button({
     fluid && styles.fluid,
     disabled && styles.disabled,
     styles[size],
-    styles[type]
+    styles[type],
+    styleOutline && styles.styleOutline
   )
 
   if (url) {
@@ -152,6 +155,7 @@ Button.propTypes = {
     color: PropTypes.string,
     width: PropTypes.string
   }),
+  styleOutline: PropTypes.bool,
   tag: PropTypes.string,
   text: PropTypes.string.isRequired,
   type: PropTypes.oneOf(['primary', 'secondary']),

--- a/components/atoms/Button/Button.js
+++ b/components/atoms/Button/Button.js
@@ -34,7 +34,6 @@ ButtonInner.propTypes = {
 /**
  * @param  {object}   props             The props object.
  * @param  {string}   props.attributes  Optional attributes to add to the button.
- * @param  {string}   props.tag         The wrapper tag.
  * @param  {string}   props.className   Optional classNames.
  * @param  {boolean}  props.disabled    Whether the button is disabled.
  * @param  {boolean}  props.fluid       Whether the button should be full width.
@@ -43,6 +42,7 @@ ButtonInner.propTypes = {
  * @param  {string}   props.iconLeft    Whether to render the icon on the left.
  * @param  {Function} props.onClick     Button onClick function.
  * @param  {string}   props.size        Button size.
+ * @param  {string}   props.tag         The wrapper tag.
  * @param  {string}   props.text        Button text.
  * @param  {string}   props.type        Button type.
  * @param  {string}   props.url         Button link url.
@@ -51,7 +51,6 @@ ButtonInner.propTypes = {
  */
 export default function Button({
   attributes,
-  tag,
   className,
   disabled,
   fluid,
@@ -60,6 +59,7 @@ export default function Button({
   iconLeft,
   onClick,
   size,
+  tag,
   text,
   type,
   url,

--- a/components/atoms/Button/Button.js
+++ b/components/atoms/Button/Button.js
@@ -148,6 +148,7 @@ Button.propTypes = {
   style: PropTypes.shape({
     background: PropTypes.string,
     backgroundColor: PropTypes.string,
+    borderRadius: PropTypes.string,
     color: PropTypes.string
   }),
   tag: PropTypes.string,

--- a/components/atoms/Button/Button.js
+++ b/components/atoms/Button/Button.js
@@ -149,7 +149,8 @@ Button.propTypes = {
     background: PropTypes.string,
     backgroundColor: PropTypes.string,
     borderRadius: PropTypes.string,
-    color: PropTypes.string
+    color: PropTypes.string,
+    width: PropTypes.string
   }),
   tag: PropTypes.string,
   text: PropTypes.string.isRequired,

--- a/components/atoms/Button/Button.js
+++ b/components/atoms/Button/Button.js
@@ -42,6 +42,7 @@ ButtonInner.propTypes = {
  * @param  {string}   props.iconLeft    Whether to render the icon on the left.
  * @param  {Function} props.onClick     Button onClick function.
  * @param  {string}   props.size        Button size.
+ * @param  {object}   props.style       Custom button styles.
  * @param  {string}   props.tag         The wrapper tag.
  * @param  {string}   props.text        Button text.
  * @param  {string}   props.type        Button type.
@@ -59,6 +60,7 @@ export default function Button({
   iconLeft,
   onClick,
   size,
+  style,
   tag,
   text,
   type,
@@ -82,6 +84,7 @@ export default function Button({
         href={url}
         className={buttonClassNames}
         aria-label={text}
+        style={style}
         {...attributes}
       >
         <ButtonInner
@@ -93,7 +96,12 @@ export default function Button({
       </a>
     ) : (
       <NextLink href={url}>
-        <a className={buttonClassNames} aria-label={text} {...attributes}>
+        <a
+          className={buttonClassNames}
+          aria-label={text}
+          style={style}
+          {...attributes}
+        >
           <ButtonInner
             icon={icon}
             iconOnly={iconOnly}
@@ -113,7 +121,8 @@ export default function Button({
           'aria-label': text,
           onClick,
           ...attributes,
-          disabled
+          disabled,
+          style
         },
         <ButtonInner
           icon={icon}
@@ -136,6 +145,11 @@ Button.propTypes = {
   iconLeft: PropTypes.bool,
   onClick: PropTypes.func,
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  style: PropTypes.shape({
+    background: PropTypes.string,
+    backgroundColor: PropTypes.string,
+    color: PropTypes.string
+  }),
   tag: PropTypes.string,
   text: PropTypes.string.isRequired,
   type: PropTypes.oneOf(['primary', 'secondary']),

--- a/components/atoms/Button/Button.module.css
+++ b/components/atoms/Button/Button.module.css
@@ -62,4 +62,9 @@
       @apply m-0;
     }
   }
+
+  /* STYLES */
+  &.styleOutline {
+    border: 2px solid;
+  }
 }

--- a/components/blocks/Gutenberg/BlockButton/BlockButton.js
+++ b/components/blocks/Gutenberg/BlockButton/BlockButton.js
@@ -49,10 +49,11 @@ export default function BlockButton({
   }
 
   // Extract button style.
-  const styleOutline = className.includes('is-style-outline')
+  const styleOutline = className && className.includes('is-style-outline')
 
   // Remove styles from className.
-  className.replace('is-style-outline', '').replace('is-style-fill', '')
+  className &&
+    className.replace('is-style-outline', '').replace('is-style-fill', '')
 
   return (
     <Button

--- a/components/blocks/Gutenberg/BlockButton/BlockButton.js
+++ b/components/blocks/Gutenberg/BlockButton/BlockButton.js
@@ -34,17 +34,30 @@ export default function BlockButton({
   url,
   width
 }) {
+  // Determine background and text colors, using stylelint-accepted const names.
+  const backgroundcolor =
+    backgroundColorHex || style?.color?.background || 'inherit'
+  const textcolor = textColorHex || style?.color?.text || 'inherit'
+
+  // Create style object for button.
+  const buttonStyle = {
+    background: style?.color?.gradient || 'inherit',
+    backgroundColor: backgroundcolor,
+    color: textcolor
+  }
+
   return (
     <Button
-      className={className}
-      text={text}
-      url={url}
-      urlExternal={true}
       attributes={{
         id: anchor || null,
         target: linkTarget || null,
         rel: rel || null
       }}
+      className={className}
+      style={buttonStyle}
+      text={text}
+      url={url}
+      urlExternal={true}
     />
   )
 }

--- a/components/blocks/Gutenberg/BlockButton/BlockButton.js
+++ b/components/blocks/Gutenberg/BlockButton/BlockButton.js
@@ -44,7 +44,8 @@ export default function BlockButton({
     background: style?.color?.gradient || 'inherit',
     backgroundColor: backgroundcolor,
     borderRadius: `${borderRadius}px`,
-    color: textcolor
+    color: textcolor,
+    width: width ? `${width}%` : 'auto'
   }
 
   return (

--- a/components/blocks/Gutenberg/BlockButton/BlockButton.js
+++ b/components/blocks/Gutenberg/BlockButton/BlockButton.js
@@ -7,22 +7,32 @@ import PropTypes from 'prop-types'
  * The core Button block from Gutenberg.
  *
  * @author WebDevStudios
- * @param  {object}  props            The component properties.
- * @param  {string}  props.anchor     Optional anchor/id.
- * @param  {string}  props.className  Optional classnames.
- * @param  {string}  props.linkTarget The target for the link.
- * @param  {string}  props.rel        The rel attribute for the link.
- * @param  {string}  props.text       The link label.
- * @param  {string}  props.url        The link for the button.
- * @return {Element}                  The Button component.
+ * @param  {object}  props                    The component properties.
+ * @param  {string}  props.anchor             Optional anchor/id.
+ * @param  {string}  props.backgroundColorHex The background color hex value.
+ * @param  {number}  props.borderRadius       The border radius in pixels.
+ * @param  {string}  props.className          Optional classnames.
+ * @param  {string}  props.linkTarget         The target for the link.
+ * @param  {string}  props.rel                The rel attribute for the link.
+ * @param  {object}  props.style              The style attributes.
+ * @param  {string}  props.text               The link label.
+ * @param  {string}  props.textColorHex       The text color hex value.
+ * @param  {string}  props.url                The link for the button.
+ * @param  {number}  props.width              The width in percent.
+ * @return {Element}                          The Button component.
  */
 export default function BlockButton({
   anchor,
+  backgroundColorHex,
+  borderRadius,
   className,
   linkTarget,
   rel,
+  style,
   text,
-  url
+  textColorHex,
+  url,
+  width
 }) {
   return (
     <Button
@@ -41,9 +51,14 @@ export default function BlockButton({
 
 BlockButton.propTypes = {
   anchor: PropTypes.string,
+  backgroundColorHex: PropTypes.string,
+  border: PropTypes.number,
   className: PropTypes.string,
   linkTarget: PropTypes.string,
   rel: PropTypes.string,
+  style: PropTypes.object,
   text: PropTypes.string,
-  url: PropTypes.string
+  textColorHex: PropTypes.string,
+  url: PropTypes.string,
+  width: PropTypes.number
 }

--- a/components/blocks/Gutenberg/BlockButton/BlockButton.js
+++ b/components/blocks/Gutenberg/BlockButton/BlockButton.js
@@ -48,6 +48,12 @@ export default function BlockButton({
     width: width ? `${width}%` : 'auto'
   }
 
+  // Extract button style.
+  const styleOutline = className.includes('is-style-outline')
+
+  // Remove styles from className.
+  className.replace('is-style-outline', '').replace('is-style-fill', '')
+
   return (
     <Button
       attributes={{
@@ -57,6 +63,7 @@ export default function BlockButton({
       }}
       className={className}
       style={buttonStyle}
+      styleOutline={styleOutline}
       text={text}
       url={url}
       urlExternal={true}

--- a/components/blocks/Gutenberg/BlockButton/BlockButton.js
+++ b/components/blocks/Gutenberg/BlockButton/BlockButton.js
@@ -43,6 +43,7 @@ export default function BlockButton({
   const buttonStyle = {
     background: style?.color?.gradient || 'inherit',
     backgroundColor: backgroundcolor,
+    borderRadius: `${borderRadius}px`,
     color: textcolor
   }
 
@@ -65,7 +66,7 @@ export default function BlockButton({
 BlockButton.propTypes = {
   anchor: PropTypes.string,
   backgroundColorHex: PropTypes.string,
-  border: PropTypes.number,
+  borderRadius: PropTypes.number,
   className: PropTypes.string,
   linkTarget: PropTypes.string,
   rel: PropTypes.string,

--- a/components/molecules/ButtonGroup/ButtonGroup.module.css
+++ b/components/molecules/ButtonGroup/ButtonGroup.module.css
@@ -2,7 +2,7 @@
   @apply mb-8;
 
   &.horizontal {
-    @apply flex;
+    @apply flex flex-wrap;
   }
 
   &.center {


### PR DESCRIPTION
References #410

Relies on [BE PR #29](https://github.com/WebDevStudios/wds-headless-wordpress/pull/29) - **BE PR must be merged first**

### Description

Adds FE handling for additional button attributes:
- styles (i.e., outline style as fill is default)
- colors: text color (preset and custom), background color (preset and custom), background gradient (custom)
- border radius
- width

### Screenshot

![Screen Shot 2021-06-03 at 3 14 19 PM](https://user-images.githubusercontent.com/36422618/120713189-c8e05300-c47e-11eb-8076-ea0dc13808d9.png)

### Verification

https://nextjs-wordpress-starter-8lfjq3xqw-webdevstudios.vercel.app/blog/410-button-block-enhancements
