### PR TITLE
Feature/410 pullquote block

### DIFF
--- a/components/atoms/PullQuote/PullQuote.js
+++ b/components/atoms/PullQuote/PullQuote.js
@@ -45,6 +45,7 @@ PullQuote.propTypes = {
   className: PropTypes.string,
   id: PropTypes.string,
   style: PropTypes.shape({
+    backgroundColor: PropTypes.string,
     color: PropTypes.string
   }),
   value: PropTypes.string

--- a/components/atoms/PullQuote/PullQuote.js
+++ b/components/atoms/PullQuote/PullQuote.js
@@ -8,13 +8,13 @@ import styles from './PullQuote.module.css'
  *
  * @author WebDevStudios
  * @param  {object}  props           The component properties.
- * @param  {string}  props.value     The pull quote content of the block.
  * @param  {string}  props.citation  The optional author citation.
- * @param  {string}  props.id        Optional anchor/id.
  * @param  {string}  props.className Optional classnames.
+ * @param  {string}  props.id        Optional anchor/id.
+ * @param  {string}  props.value     The pull quote content of the block.
  * @return {Element}                 The PullQuote component.
  */
-export default function PullQuote({value, citation, id, className}) {
+export default function PullQuote({citation, className, id, value}) {
   return (
     <>
       {!!value && (
@@ -36,8 +36,8 @@ export default function PullQuote({value, citation, id, className}) {
 }
 
 PullQuote.propTypes = {
-  id: PropTypes.string,
+  citation: PropTypes.string,
   className: PropTypes.string,
-  value: PropTypes.string,
-  citation: PropTypes.string
+  id: PropTypes.string,
+  value: PropTypes.string
 }

--- a/components/atoms/PullQuote/PullQuote.js
+++ b/components/atoms/PullQuote/PullQuote.js
@@ -11,14 +11,19 @@ import styles from './PullQuote.module.css'
  * @param  {string}  props.citation  The optional author citation.
  * @param  {string}  props.className Optional classnames.
  * @param  {string}  props.id        Optional anchor/id.
+ * @param  {object}  props.style     Custom pullquote styles.
  * @param  {string}  props.value     The pull quote content of the block.
  * @return {Element}                 The PullQuote component.
  */
-export default function PullQuote({citation, className, id, value}) {
+export default function PullQuote({citation, className, id, style, value}) {
   return (
     <>
       {!!value && (
-        <figure id={id ? id : null} className={cn(styles.pullquote, className)}>
+        <figure
+          id={id ? id : null}
+          className={cn(styles.pullquote, className)}
+          style={style}
+        >
           <blockquote>
             <div className={styles.content}>
               <RichText tag="div">{value}</RichText>
@@ -39,5 +44,8 @@ PullQuote.propTypes = {
   citation: PropTypes.string,
   className: PropTypes.string,
   id: PropTypes.string,
+  style: PropTypes.shape({
+    color: PropTypes.string
+  }),
   value: PropTypes.string
 }

--- a/components/atoms/PullQuote/PullQuote.js
+++ b/components/atoms/PullQuote/PullQuote.js
@@ -7,33 +7,47 @@ import styles from './PullQuote.module.css'
  * PullQuote Block
  *
  * @author WebDevStudios
- * @param  {object}  props           The component properties.
- * @param  {string}  props.citation  The optional author citation.
- * @param  {string}  props.className Optional classnames.
- * @param  {string}  props.id        Optional anchor/id.
- * @param  {object}  props.style     Custom pullquote styles.
- * @param  {string}  props.value     The pull quote content of the block.
- * @return {Element}                 The PullQuote component.
+ * @param  {object}  props            The component properties.
+ * @param  {string}  props.citation   The optional author citation.
+ * @param  {string}  props.className  Optional classnames.
+ * @param  {string}  props.id         Optional anchor/id.
+ * @param  {object}  props.style      Custom pullquote styles.
+ * @param  {boolean} props.styleSolid Whether this pullquote has the solid style.
+ * @param  {string}  props.value      The pull quote content of the block.
+ * @return {Element}                  The PullQuote component.
  */
-export default function PullQuote({citation, className, id, style, value}) {
+export default function PullQuote({
+  citation,
+  className,
+  id,
+  style,
+  styleSolid,
+  value
+}) {
   return (
     <>
       {!!value && (
         <figure
           id={id ? id : null}
-          className={cn(styles.pullquote, className)}
+          className={cn(
+            styles.pullquote,
+            className,
+            styleSolid && styles.styleSolid
+          )}
           style={style}
         >
-          <blockquote>
-            <div className={styles.content}>
-              <RichText tag="div">{value}</RichText>
-            </div>
-          </blockquote>
-          {!!citation && (
-            <figcaption className={styles.cite}>
-              ~ <RichText tag="span">{citation}</RichText>
-            </figcaption>
-          )}
+          <div className={styles.wrap}>
+            <blockquote>
+              <div className={styles.content}>
+                <RichText tag="div">{value}</RichText>
+              </div>
+            </blockquote>
+            {!!citation && (
+              <figcaption className={styles.cite}>
+                ~ <RichText tag="span">{citation}</RichText>
+              </figcaption>
+            )}
+          </div>
         </figure>
       )}
     </>
@@ -48,5 +62,6 @@ PullQuote.propTypes = {
     backgroundColor: PropTypes.string,
     color: PropTypes.string
   }),
+  styleSolid: PropTypes.bool,
   value: PropTypes.string
 }

--- a/components/atoms/PullQuote/PullQuote.module.css
+++ b/components/atoms/PullQuote/PullQuote.module.css
@@ -8,4 +8,10 @@
   & figcaption {
     @apply font-bold;
   }
+
+  &.styleSolid {
+    & .wrap {
+      @apply max-w-60 text-left mr-auto ml-auto;
+    }
+  }
 }

--- a/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
+++ b/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
@@ -7,20 +7,34 @@ import PropTypes from 'prop-types'
  * The core Pull Quote block from Gutenberg.
  *
  * @author WebDevStudios
- * @param  {object}  props           The component props.
- * @param  {string}  props.anchor    Optional anchor/id.
- * @param  {string}  props.citation  The optional author citation.
- * @param  {string}  props.className Optional classnames.
- * @param  {string}  props.value     The quote content of the block.
- * @return {Element}                 The Quote component.
+ * @param  {object}  props                 The component props.
+ * @param  {string}  props.anchor          Optional anchor/id.
+ * @param  {string}  props.citation        The optional author citation.
+ * @param  {string}  props.className       Optional classnames.
+ * @param  {string}  props.customTextColor The custom text color.
+ * @param  {string}  props.textColorHex    The text color hex value.
+ * @param  {string}  props.value           The quote content of the block.
+ * @return {Element}                       The Quote component.
  */
-export default function BlockPullQuote({anchor, citation, className, value}) {
+export default function BlockPullQuote(props) {
+  const {anchor, citation, className, customTextColor, textColorHex, value} =
+    props
+
+  // Determine background and text colors, using stylelint-accepted const names.
+  const textcolor = textColorHex || customTextColor || 'inherit'
+
+  // Create style object for pullquote.
+  const pullQuoteStyle = {
+    color: textcolor
+  }
+
   return (
     <PullQuote
-      id={anchor}
-      className={className}
-      value={value}
       citation={citation}
+      className={className}
+      id={anchor}
+      style={pullQuoteStyle}
+      value={value}
     />
   )
 }
@@ -29,5 +43,7 @@ BlockPullQuote.propTypes = {
   anchor: PropTypes.string,
   citation: PropTypes.string,
   className: PropTypes.string,
+  customTextColor: PropTypes.string,
+  textColorHex: PropTypes.string,
   value: PropTypes.string
 }

--- a/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
+++ b/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
@@ -60,6 +60,7 @@ export default function BlockPullQuote(props) {
       className={className}
       id={anchor}
       style={pullQuoteStyle}
+      styleSolid={styleSolid}
       value={value}
     />
   )

--- a/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
+++ b/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
@@ -18,18 +18,16 @@ import PropTypes from 'prop-types'
  * @param  {string}  props.value           The quote content of the block.
  * @return {Element}                       The Quote component.
  */
-export default function BlockPullQuote(props) {
-  const {
-    anchor,
-    citation,
-    className,
-    customMainColor,
-    customTextColor,
-    mainColorHex,
-    textColorHex,
-    value
-  } = props
-
+export default function BlockPullQuote({
+  anchor,
+  citation,
+  className,
+  customMainColor,
+  customTextColor,
+  mainColorHex,
+  textColorHex,
+  value
+}) {
   // Determine background and text colors, using stylelint-accepted const names.
   const backgroundcolor = mainColorHex || customMainColor || 'inherit'
   const textcolor = textColorHex || customTextColor || 'inherit'

--- a/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
+++ b/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types'
  * @param  {string}  props.className       Optional classnames.
  * @param  {string}  props.customMainColor The custom background color.
  * @param  {string}  props.customTextColor The custom text color.
- * @param  {string}  props.mainColorHex The background color hex value.
+ * @param  {string}  props.mainColorHex    The background color hex value.
  * @param  {string}  props.textColorHex    The text color hex value.
  * @param  {string}  props.value           The quote content of the block.
  * @return {Element}                       The Quote component.
@@ -38,6 +38,20 @@ export default function BlockPullQuote(props) {
   const pullQuoteStyle = {
     backgroundColor: backgroundcolor,
     color: textcolor
+  }
+
+  // Extract pullquote style.
+  const styleSolid = className && className.includes('is-style-solid-color')
+
+  // Remove styles from className.
+  className &&
+    className
+      .replace('is-style-solid-color', '')
+      .replace('is-style-default', '')
+
+  // Remove background for default style.
+  if (!styleSolid) {
+    pullQuoteStyle.backgroundColor = 'inherit'
   }
 
   return (

--- a/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
+++ b/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
@@ -8,13 +8,13 @@ import PropTypes from 'prop-types'
  *
  * @author WebDevStudios
  * @param  {object}  props           The component props.
- * @param  {string}  props.value     The quote content of the block.
- * @param  {string}  props.citation  The optional author citation.
  * @param  {string}  props.anchor    Optional anchor/id.
+ * @param  {string}  props.citation  The optional author citation.
  * @param  {string}  props.className Optional classnames.
+ * @param  {string}  props.value     The quote content of the block.
  * @return {Element}                 The Quote component.
  */
-export default function BlockPullQuote({value, citation, anchor, className}) {
+export default function BlockPullQuote({anchor, citation, className, value}) {
   return (
     <PullQuote
       id={anchor}
@@ -26,8 +26,8 @@ export default function BlockPullQuote({value, citation, anchor, className}) {
 }
 
 BlockPullQuote.propTypes = {
-  value: PropTypes.string,
-  citation: PropTypes.string,
   anchor: PropTypes.string,
-  className: PropTypes.string
+  citation: PropTypes.string,
+  className: PropTypes.string,
+  value: PropTypes.string
 }

--- a/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
+++ b/components/blocks/Gutenberg/BlockPullQuote/BlockPullQuote.js
@@ -11,20 +11,32 @@ import PropTypes from 'prop-types'
  * @param  {string}  props.anchor          Optional anchor/id.
  * @param  {string}  props.citation        The optional author citation.
  * @param  {string}  props.className       Optional classnames.
+ * @param  {string}  props.customMainColor The custom background color.
  * @param  {string}  props.customTextColor The custom text color.
+ * @param  {string}  props.mainColorHex The background color hex value.
  * @param  {string}  props.textColorHex    The text color hex value.
  * @param  {string}  props.value           The quote content of the block.
  * @return {Element}                       The Quote component.
  */
 export default function BlockPullQuote(props) {
-  const {anchor, citation, className, customTextColor, textColorHex, value} =
-    props
+  const {
+    anchor,
+    citation,
+    className,
+    customMainColor,
+    customTextColor,
+    mainColorHex,
+    textColorHex,
+    value
+  } = props
 
   // Determine background and text colors, using stylelint-accepted const names.
+  const backgroundcolor = mainColorHex || customMainColor || 'inherit'
   const textcolor = textColorHex || customTextColor || 'inherit'
 
   // Create style object for pullquote.
   const pullQuoteStyle = {
+    backgroundColor: backgroundcolor,
     color: textcolor
   }
 
@@ -43,7 +55,9 @@ BlockPullQuote.propTypes = {
   anchor: PropTypes.string,
   citation: PropTypes.string,
   className: PropTypes.string,
+  customMainColor: PropTypes.string,
   customTextColor: PropTypes.string,
+  mainColorHex: PropTypes.string,
   textColorHex: PropTypes.string,
   value: PropTypes.string
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,9 @@ module.exports = {
           lg: '1024px',
           xl: '1280px'
         }
+      },
+      maxWidth: {
+        60: '60%'
       }
     }
   },


### PR DESCRIPTION
References #410

Relies on [BE PR #30](https://github.com/WebDevStudios/wds-headless-wordpress/pull/30) - **BE PR must be merged first**

### Description

Adds FE handling for additional pullquote attributes:
- styles (i.e., solid color vs default)
- colors: text and background ("main") colors (preset and custom)

### Screenshot

![Screen Shot 2021-06-04 at 11 03 16 AM](https://user-images.githubusercontent.com/36422618/120838825-7dcd4b00-c525-11eb-898c-832e90c35a85.png)

### Verification

https://nextjs-wordpress-starter-1woadfaqc-webdevstudios.vercel.app/blog/410-pullquote-block-enhancements
