### PR TITLE
Feature/410 media text block

### DIFF
--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -14,14 +14,49 @@ import PropTypes from 'prop-types'
  * @return {Element}                   The Code component.
  */
 export default function BlockMediaText({innerBlocks, media}) {
+  /* eslint-disable no-unused-vars */
+  const {
+    anchor,
+    backgroundColorHex,
+    caption,
+    className,
+    href,
+    linkClass,
+    linkTarget,
+    mediaAlt,
+    mediaId,
+    mediaPosition,
+    mediaType,
+    mediaUrl,
+    rel,
+    sizeSlug,
+    style,
+    textColorHex
+  } = media
+  /* eslint-enable no-unused-vars */
+
+  // Determine background and text colors, using stylelint-accepted const names.
+  const backgroundcolor =
+    backgroundColorHex || style?.color?.background || 'inherit'
+  const textcolor = textColorHex || style?.color?.text || 'inherit'
+
+  // Create style object for button.
+  const mediaTextStyle = {
+    background: style?.color?.gradient || 'inherit',
+    backgroundColor: backgroundcolor,
+    color: textcolor
+    // width: width ? `${width}%` : 'auto'
+  }
+
   return (
     <>
       {!!media && innerBlocks?.length && (
         <MediaText
-          id={media?.anchor}
-          className={media?.className}
-          mediaLeft={media?.mediaPosition === 'left' ? true : false}
-          image={{url: media?.mediaUrl, alt: media?.mediaAlt}}
+          className={className}
+          id={anchor}
+          image={{url: mediaUrl, alt: mediaAlt}}
+          mediaLeft={mediaPosition === 'left' ? true : false}
+          style={mediaTextStyle}
         >
           <Blocks blocks={innerBlocks} />
         </MediaText>
@@ -39,6 +74,7 @@ BlockMediaText.propTypes = {
   ),
   media: PropTypes.shape({
     anchor: PropTypes.string,
+    backgroundColorHex: PropTypes.string,
     caption: PropTypes.string,
     className: PropTypes.string,
     href: PropTypes.string,
@@ -50,7 +86,9 @@ BlockMediaText.propTypes = {
     mediaType: PropTypes.string,
     mediaUrl: PropTypes.string,
     rel: PropTypes.string,
-    sizeSlug: PropTypes.string
+    sizeSlug: PropTypes.string,
+    style: PropTypes.object,
+    textColorHex: PropTypes.string
   })
 }
 BlockMediaText.defaultProps = {

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -33,7 +33,8 @@ export default function BlockMediaText({innerBlocks, media}) {
     rel,
     sizeSlug,
     style,
-    textColorHex
+    textColorHex,
+    verticalAlignment
   } = media
   /* eslint-enable no-unused-vars */
 
@@ -61,6 +62,7 @@ export default function BlockMediaText({innerBlocks, media}) {
           mediaWidth={mediaWidth}
           style={mediaTextStyle}
           stackOnMobile={isStackedOnMobile}
+          verticalAlignment={verticalAlignment}
         >
           <Blocks blocks={innerBlocks} />
         </MediaText>
@@ -94,7 +96,8 @@ BlockMediaText.propTypes = {
     rel: PropTypes.string,
     sizeSlug: PropTypes.string,
     style: PropTypes.object,
-    textColorHex: PropTypes.string
+    textColorHex: PropTypes.string,
+    verticalAlignment: PropTypes.string
   })
 }
 BlockMediaText.defaultProps = {

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -21,6 +21,7 @@ export default function BlockMediaText({innerBlocks, media}) {
     caption,
     className,
     href,
+    imageFill,
     isStackedOnMobile,
     linkClass,
     linkTarget,
@@ -58,6 +59,7 @@ export default function BlockMediaText({innerBlocks, media}) {
           className={className}
           id={anchor}
           image={{url: mediaUrl, alt: mediaAlt}}
+          imageFill={imageFill}
           mediaLeft={mediaPosition === 'left' ? true : false}
           mediaWidth={mediaWidth}
           style={mediaTextStyle}
@@ -84,6 +86,7 @@ BlockMediaText.propTypes = {
     caption: PropTypes.string,
     className: PropTypes.string,
     href: PropTypes.string,
+    imageFill: PropTypes.bool,
     isStackedOnMobile: PropTypes.bool,
     linkClass: PropTypes.string,
     linkTarget: PropTypes.string,

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -21,6 +21,7 @@ export default function BlockMediaText({innerBlocks, media}) {
     caption,
     className,
     focalPoint,
+    gradientHex,
     href,
     imageFill,
     isStackedOnMobile,
@@ -47,7 +48,7 @@ export default function BlockMediaText({innerBlocks, media}) {
 
   // Create style object for button.
   const mediaTextStyle = {
-    background: style?.color?.gradient || 'inherit',
+    background: gradientHex || style?.color?.gradient || 'inherit',
     backgroundColor: backgroundcolor,
     color: textcolor,
     gridTemplateColumns: `1fr ${mediaWidth}%`
@@ -102,6 +103,7 @@ BlockMediaText.propTypes = {
       x: PropTypes.string,
       y: PropTypes.string
     }),
+    gradientHex: PropTypes.string,
     href: PropTypes.string,
     imageFill: PropTypes.bool,
     isStackedOnMobile: PropTypes.bool,

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -21,6 +21,7 @@ export default function BlockMediaText({innerBlocks, media}) {
     caption,
     className,
     href,
+    isStackedOnMobile,
     linkClass,
     linkTarget,
     mediaAlt,
@@ -59,6 +60,7 @@ export default function BlockMediaText({innerBlocks, media}) {
           mediaLeft={mediaPosition === 'left' ? true : false}
           mediaWidth={mediaWidth}
           style={mediaTextStyle}
+          stackOnMobile={isStackedOnMobile}
         >
           <Blocks blocks={innerBlocks} />
         </MediaText>
@@ -80,6 +82,7 @@ BlockMediaText.propTypes = {
     caption: PropTypes.string,
     className: PropTypes.string,
     href: PropTypes.string,
+    isStackedOnMobile: PropTypes.bool,
     linkClass: PropTypes.string,
     linkTarget: PropTypes.string,
     mediaAlt: PropTypes.string,

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -45,7 +45,8 @@ export default function BlockMediaText({innerBlocks, media}) {
   const mediaTextStyle = {
     background: style?.color?.gradient || 'inherit',
     backgroundColor: backgroundcolor,
-    color: textcolor
+    color: textcolor,
+    gridTemplateColumns: `1fr ${mediaWidth}%`
   }
 
   return (

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -27,6 +27,7 @@ export default function BlockMediaText({innerBlocks, media}) {
     mediaId,
     mediaPosition,
     mediaType,
+    mediaWidth,
     mediaUrl,
     rel,
     sizeSlug,
@@ -45,7 +46,6 @@ export default function BlockMediaText({innerBlocks, media}) {
     background: style?.color?.gradient || 'inherit',
     backgroundColor: backgroundcolor,
     color: textcolor
-    // width: width ? `${width}%` : 'auto'
   }
 
   return (
@@ -56,6 +56,7 @@ export default function BlockMediaText({innerBlocks, media}) {
           id={anchor}
           image={{url: mediaUrl, alt: mediaAlt}}
           mediaLeft={mediaPosition === 'left' ? true : false}
+          mediaWidth={mediaWidth}
           style={mediaTextStyle}
         >
           <Blocks blocks={innerBlocks} />
@@ -84,6 +85,7 @@ BlockMediaText.propTypes = {
     mediaId: PropTypes.number,
     mediaPosition: PropTypes.string,
     mediaType: PropTypes.string,
+    mediaWidth: PropTypes.number,
     mediaUrl: PropTypes.string,
     rel: PropTypes.string,
     sizeSlug: PropTypes.string,

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -46,13 +46,15 @@ export default function BlockMediaText({innerBlocks, media}) {
     backgroundColorHex || style?.color?.background || 'inherit'
   const textcolor = textColorHex || style?.color?.text || 'inherit'
   const background = gradientHex || style?.color?.gradient || 'inherit'
+  const gridtemplatecolumns =
+    mediaPosition === 'left' ? `${mediaWidth}% 1fr` : `1fr ${mediaWidth}%`
 
   // Create style object for button.
   const mediaTextStyle = {
     background: background,
     backgroundColor: backgroundcolor,
     color: textcolor,
-    gridTemplateColumns: `1fr ${mediaWidth}%`
+    gridTemplateColumns: gridtemplatecolumns
   }
 
   const newFocalPoint = {}

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -9,11 +9,11 @@ import PropTypes from 'prop-types'
  *
  * @author WebDevStudios
  * @param  {object}  props             The component properties.
- * @param  {object}  props.media       Media props.
  * @param  {Array}   props.innerBlocks The array of inner blocks to display.
+ * @param  {object}  props.media       Media props.
  * @return {Element}                   The Code component.
  */
-export default function BlockMediaText({media, innerBlocks}) {
+export default function BlockMediaText({innerBlocks, media}) {
   return (
     <>
       {!!media && innerBlocks?.length && (
@@ -31,27 +31,27 @@ export default function BlockMediaText({media, innerBlocks}) {
 }
 
 BlockMediaText.propTypes = {
+  innerBlocks: PropTypes.arrayOf(
+    PropTypes.shape({
+      attributes: PropTypes.object,
+      name: PropTypes.string
+    })
+  ),
   media: PropTypes.shape({
     anchor: PropTypes.string,
     caption: PropTypes.string,
     className: PropTypes.string,
     href: PropTypes.string,
-    linkTarget: PropTypes.string,
     linkClass: PropTypes.string,
-    rel: PropTypes.string,
-    sizeSlug: PropTypes.string,
+    linkTarget: PropTypes.string,
     mediaAlt: PropTypes.string,
     mediaId: PropTypes.number,
+    mediaPosition: PropTypes.string,
     mediaType: PropTypes.string,
     mediaUrl: PropTypes.string,
-    mediaPosition: PropTypes.string
-  }),
-  innerBlocks: PropTypes.arrayOf(
-    PropTypes.shape({
-      name: PropTypes.string,
-      attributes: PropTypes.object
-    })
-  )
+    rel: PropTypes.string,
+    sizeSlug: PropTypes.string
+  })
 }
 BlockMediaText.defaultProps = {
   media: PropTypes.shape({

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -45,10 +45,11 @@ export default function BlockMediaText({innerBlocks, media}) {
   const backgroundcolor =
     backgroundColorHex || style?.color?.background || 'inherit'
   const textcolor = textColorHex || style?.color?.text || 'inherit'
+  const background = gradientHex || style?.color?.gradient || 'inherit'
 
   // Create style object for button.
   const mediaTextStyle = {
-    background: gradientHex || style?.color?.gradient || 'inherit',
+    background: background,
     backgroundColor: backgroundcolor,
     color: textcolor,
     gridTemplateColumns: `1fr ${mediaWidth}%`

--- a/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
+++ b/components/blocks/Gutenberg/BlockMediaText/BlockMediaText.js
@@ -20,6 +20,7 @@ export default function BlockMediaText({innerBlocks, media}) {
     backgroundColorHex,
     caption,
     className,
+    focalPoint,
     href,
     imageFill,
     isStackedOnMobile,
@@ -52,11 +53,23 @@ export default function BlockMediaText({innerBlocks, media}) {
     gridTemplateColumns: `1fr ${mediaWidth}%`
   }
 
+  const newFocalPoint = {}
+
+  // Convert focal point values to percent.
+  if (imageFill) {
+    const x = parseFloat(focalPoint?.x || '.5') ?? 0.5
+    const y = parseFloat(focalPoint?.y || '.5') ?? 0.5
+
+    newFocalPoint.x = `${x * 100}%`
+    newFocalPoint.y = `${y * 100}%`
+  }
+
   return (
     <>
       {!!media && innerBlocks?.length && (
         <MediaText
           className={className}
+          focalPoint={newFocalPoint}
           id={anchor}
           image={{url: mediaUrl, alt: mediaAlt}}
           imageFill={imageFill}
@@ -85,6 +98,10 @@ BlockMediaText.propTypes = {
     backgroundColorHex: PropTypes.string,
     caption: PropTypes.string,
     className: PropTypes.string,
+    focalPoint: PropTypes.shape({
+      x: PropTypes.string,
+      y: PropTypes.string
+    }),
     href: PropTypes.string,
     imageFill: PropTypes.bool,
     isStackedOnMobile: PropTypes.bool,

--- a/components/organisms/MediaText/MediaText.js
+++ b/components/organisms/MediaText/MediaText.js
@@ -8,18 +8,19 @@ import styles from './MediaText.module.css'
 /**
  * Render the MediaText component.
  *
- * @param  {object}  props               MediaText component props.
- * @param  {string}  props.body          The body text.
- * @param  {Element} props.children      The child elements.
- * @param  {string}  props.className     The className.
- * @param  {object}  props.cta           The cta object with text and url strings.
- * @param  {string}  props.id            Optional element ID.
- * @param  {object}  props.image         The image object with url and alt text.
- * @param  {boolean} props.mediaLeft     Whether to show media on the left of the text.
- * @param  {boolean} props.stackOnMobile Whether to stack media and text on mobile.
- * @param  {object}  props.style         Custom media text styles.
- * @param  {string}  props.title         The title.
- * @return {Element}                     The MediaText component.
+ * @param  {object}  props                   MediaText component props.
+ * @param  {string}  props.body              The body text.
+ * @param  {Element} props.children          The child elements.
+ * @param  {string}  props.className         The className.
+ * @param  {object}  props.cta               The cta object with text and url strings.
+ * @param  {string}  props.id                Optional element ID.
+ * @param  {object}  props.image             The image object with url and alt text.
+ * @param  {boolean} props.mediaLeft         Whether to show media on the left of the text.
+ * @param  {boolean} props.stackOnMobile     Whether to stack media and text on mobile.
+ * @param  {object}  props.style             Custom media text styles.
+ * @param  {string}  props.title             The title.
+ * @param  {string}  props.verticalAlignment Vertical alignment of text.
+ * @return {Element}                         The MediaText component.
  */
 export default function MediaText({
   body,
@@ -31,7 +32,8 @@ export default function MediaText({
   mediaLeft,
   stackOnMobile,
   style,
-  title
+  title,
+  verticalAlignment
 }) {
   useEffect(() => {
     if ((children && title) || (children && body) || (children && cta)) {
@@ -48,7 +50,9 @@ export default function MediaText({
         styles.mediaText,
         mediaLeft ? styles.mediaLeft : null,
         className,
-        !stackOnMobile ? styles.noStack : null
+        !stackOnMobile ? styles.noStack : null,
+        verticalAlignment === 'top' ? styles.alignTop : null,
+        verticalAlignment === 'bottom' ? styles.alignBottom : null
       )}
       style={style}
     >
@@ -107,7 +111,8 @@ MediaText.propTypes = {
     backgroundColor: PropTypes.string,
     color: PropTypes.string
   }),
-  title: PropTypes.string
+  title: PropTypes.string,
+  verticalAlignment: PropTypes.string
 }
 
 MediaText.defaultProps = {

--- a/components/organisms/MediaText/MediaText.js
+++ b/components/organisms/MediaText/MediaText.js
@@ -8,17 +8,18 @@ import styles from './MediaText.module.css'
 /**
  * Render the MediaText component.
  *
- * @param  {object}  props           MediaText component props.
- * @param  {string}  props.body      The body text.
- * @param  {Element} props.children  The child elements.
- * @param  {string}  props.className The className.
- * @param  {object}  props.cta       The cta object with text and url strings.
- * @param  {string}  props.id        Optional element ID.
- * @param  {object}  props.image     The image object with url and alt text.
- * @param  {boolean} props.mediaLeft Whether to show media on the left of the text.
- * @param  {object}  props.style     Custom media text styles.
- * @param  {string}  props.title     The title.
- * @return {Element}                 The MediaText component.
+ * @param  {object}  props            MediaText component props.
+ * @param  {string}  props.body       The body text.
+ * @param  {Element} props.children   The child elements.
+ * @param  {string}  props.className  The className.
+ * @param  {object}  props.cta        The cta object with text and url strings.
+ * @param  {string}  props.id         Optional element ID.
+ * @param  {object}  props.image      The image object with url and alt text.
+ * @param  {boolean} props.mediaLeft  Whether to show media on the left of the text.
+ * @param  {number}  props.mediaWidth The media width in percent.
+ * @param  {object}  props.style      Custom media text styles.
+ * @param  {string}  props.title      The title.
+ * @return {Element}                  The MediaText component.
  */
 export default function MediaText({
   body,
@@ -28,6 +29,7 @@ export default function MediaText({
   id,
   image,
   mediaLeft,
+  mediaWidth,
   style,
   title
 }) {
@@ -39,6 +41,10 @@ export default function MediaText({
     }
   })
 
+  // Calculate media and text widths in percent.
+  const mediawidth = `${mediaWidth ?? 50}%`
+  const textwidth = `${100 - (mediaWidth ?? 50)}%`
+
   return (
     <section
       id={id}
@@ -49,7 +55,7 @@ export default function MediaText({
       )}
       style={style}
     >
-      <div className={styles.text}>
+      <div className={styles.text} style={{width: textwidth}}>
         {children ? (
           children
         ) : (
@@ -69,7 +75,7 @@ export default function MediaText({
           </>
         )}
       </div>
-      <div className={styles.media}>
+      <div className={styles.media} style={{width: mediawidth}}>
         {image && image.url && (
           <DisplayImage
             className={styles.imageWrap}
@@ -98,6 +104,7 @@ MediaText.propTypes = {
     alt: PropTypes.string
   }),
   mediaLeft: PropTypes.bool,
+  mediaWidth: PropTypes.number,
   style: PropTypes.shape({
     background: PropTypes.string,
     backgroundColor: PropTypes.string,

--- a/components/organisms/MediaText/MediaText.js
+++ b/components/organisms/MediaText/MediaText.js
@@ -16,6 +16,7 @@ import styles from './MediaText.module.css'
  * @param  {string}  props.id        Optional element ID.
  * @param  {object}  props.image     The image object with url and alt text.
  * @param  {boolean} props.mediaLeft Whether to show media on the left of the text.
+ * @param  {object}  props.style     Custom media text styles.
  * @param  {string}  props.title     The title.
  * @return {Element}                 The MediaText component.
  */
@@ -27,6 +28,7 @@ export default function MediaText({
   id,
   image,
   mediaLeft,
+  style,
   title
 }) {
   useEffect(() => {
@@ -45,6 +47,7 @@ export default function MediaText({
         mediaLeft ? styles.mediaLeft : null,
         className
       )}
+      style={style}
     >
       <div className={styles.text}>
         {children ? (
@@ -95,6 +98,11 @@ MediaText.propTypes = {
     alt: PropTypes.string
   }),
   mediaLeft: PropTypes.bool,
+  style: PropTypes.shape({
+    background: PropTypes.string,
+    backgroundColor: PropTypes.string,
+    color: PropTypes.string
+  }),
   title: PropTypes.string
 }
 

--- a/components/organisms/MediaText/MediaText.js
+++ b/components/organisms/MediaText/MediaText.js
@@ -55,7 +55,7 @@ export default function MediaText({
         !stackOnMobile ? styles.noStack : null,
         verticalAlignment === 'top' ? styles.alignTop : null,
         verticalAlignment === 'bottom' ? styles.alignBottom : null,
-        imageFill ? styles.imageFill : null
+        imageFill && image?.url ? styles.imageFill : null
       )}
       style={style}
     >
@@ -79,7 +79,12 @@ export default function MediaText({
           </>
         )}
       </div>
-      <div className={styles.media}>
+      <div
+        className={styles.media}
+        style={{
+          backgroundImage: `url(${image?.url || ''})`
+        }}
+      >
         {image && image.url && (
           <DisplayImage
             className={styles.imageWrap}

--- a/components/organisms/MediaText/MediaText.js
+++ b/components/organisms/MediaText/MediaText.js
@@ -8,18 +8,17 @@ import styles from './MediaText.module.css'
 /**
  * Render the MediaText component.
  *
- * @param  {object}  props            MediaText component props.
- * @param  {string}  props.body       The body text.
- * @param  {Element} props.children   The child elements.
- * @param  {string}  props.className  The className.
- * @param  {object}  props.cta        The cta object with text and url strings.
- * @param  {string}  props.id         Optional element ID.
- * @param  {object}  props.image      The image object with url and alt text.
- * @param  {boolean} props.mediaLeft  Whether to show media on the left of the text.
- * @param  {number}  props.mediaWidth The media width in percent.
- * @param  {object}  props.style      Custom media text styles.
- * @param  {string}  props.title      The title.
- * @return {Element}                  The MediaText component.
+ * @param  {object}  props           MediaText component props.
+ * @param  {string}  props.body      The body text.
+ * @param  {Element} props.children  The child elements.
+ * @param  {string}  props.className The className.
+ * @param  {object}  props.cta       The cta object with text and url strings.
+ * @param  {string}  props.id        Optional element ID.
+ * @param  {object}  props.image     The image object with url and alt text.
+ * @param  {boolean} props.mediaLeft Whether to show media on the left of the text.
+ * @param  {object}  props.style     Custom media text styles.
+ * @param  {string}  props.title     The title.
+ * @return {Element}                 The MediaText component.
  */
 export default function MediaText({
   body,
@@ -29,7 +28,6 @@ export default function MediaText({
   id,
   image,
   mediaLeft,
-  mediaWidth,
   style,
   title
 }) {
@@ -41,10 +39,6 @@ export default function MediaText({
     }
   })
 
-  // Calculate media and text widths in percent.
-  const mediawidth = `${mediaWidth ?? 50}%`
-  const textwidth = `${100 - (mediaWidth ?? 50)}%`
-
   return (
     <section
       id={id}
@@ -55,7 +49,7 @@ export default function MediaText({
       )}
       style={style}
     >
-      <div className={styles.text} style={{width: textwidth}}>
+      <div className={styles.text}>
         {children ? (
           children
         ) : (
@@ -75,7 +69,7 @@ export default function MediaText({
           </>
         )}
       </div>
-      <div className={styles.media} style={{width: mediawidth}}>
+      <div className={styles.media}>
         {image && image.url && (
           <DisplayImage
             className={styles.imageWrap}
@@ -104,7 +98,6 @@ MediaText.propTypes = {
     alt: PropTypes.string
   }),
   mediaLeft: PropTypes.bool,
-  mediaWidth: PropTypes.number,
   style: PropTypes.shape({
     background: PropTypes.string,
     backgroundColor: PropTypes.string,

--- a/components/organisms/MediaText/MediaText.js
+++ b/components/organisms/MediaText/MediaText.js
@@ -15,6 +15,7 @@ import styles from './MediaText.module.css'
  * @param  {object}  props.cta               The cta object with text and url strings.
  * @param  {string}  props.id                Optional element ID.
  * @param  {object}  props.image             The image object with url and alt text.
+ * @param  {boolean} props.imageFill         Whether to crop image to fill.
  * @param  {boolean} props.mediaLeft         Whether to show media on the left of the text.
  * @param  {boolean} props.stackOnMobile     Whether to stack media and text on mobile.
  * @param  {object}  props.style             Custom media text styles.
@@ -29,6 +30,7 @@ export default function MediaText({
   cta,
   id,
   image,
+  imageFill,
   mediaLeft,
   stackOnMobile,
   style,
@@ -52,7 +54,8 @@ export default function MediaText({
         className,
         !stackOnMobile ? styles.noStack : null,
         verticalAlignment === 'top' ? styles.alignTop : null,
-        verticalAlignment === 'bottom' ? styles.alignBottom : null
+        verticalAlignment === 'bottom' ? styles.alignBottom : null,
+        imageFill ? styles.imageFill : null
       )}
       style={style}
     >
@@ -104,6 +107,7 @@ MediaText.propTypes = {
     url: PropTypes.string,
     alt: PropTypes.string
   }),
+  imageFill: PropTypes.bool,
   mediaLeft: PropTypes.bool,
   stackOnMobile: PropTypes.bool,
   style: PropTypes.shape({

--- a/components/organisms/MediaText/MediaText.js
+++ b/components/organisms/MediaText/MediaText.js
@@ -13,6 +13,7 @@ import styles from './MediaText.module.css'
  * @param  {Element} props.children          The child elements.
  * @param  {string}  props.className         The className.
  * @param  {object}  props.cta               The cta object with text and url strings.
+ * @param  {object}  props.focalPoint        The focal point coordinates for the image fill setting.
  * @param  {string}  props.id                Optional element ID.
  * @param  {object}  props.image             The image object with url and alt text.
  * @param  {boolean} props.imageFill         Whether to crop image to fill.
@@ -28,6 +29,7 @@ export default function MediaText({
   children,
   className,
   cta,
+  focalPoint,
   id,
   image,
   imageFill,
@@ -82,7 +84,8 @@ export default function MediaText({
       <div
         className={styles.media}
         style={{
-          backgroundImage: `url(${image?.url || ''})`
+          backgroundImage: `url(${image?.url || ''})`,
+          backgroundPosition: `${focalPoint.x} ${focalPoint.y}`
         }}
       >
         {image && image.url && (
@@ -106,6 +109,10 @@ MediaText.propTypes = {
     text: PropTypes.string,
     url: PropTypes.string,
     icon: PropTypes.string
+  }),
+  focalPoint: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string
   }),
   id: PropTypes.string,
   image: PropTypes.shape({

--- a/components/organisms/MediaText/MediaText.js
+++ b/components/organisms/MediaText/MediaText.js
@@ -8,17 +8,18 @@ import styles from './MediaText.module.css'
 /**
  * Render the MediaText component.
  *
- * @param  {object}  props           MediaText component props.
- * @param  {string}  props.body      The body text.
- * @param  {Element} props.children  The child elements.
- * @param  {string}  props.className The className.
- * @param  {object}  props.cta       The cta object with text and url strings.
- * @param  {string}  props.id        Optional element ID.
- * @param  {object}  props.image     The image object with url and alt text.
- * @param  {boolean} props.mediaLeft Whether to show media on the left of the text.
- * @param  {object}  props.style     Custom media text styles.
- * @param  {string}  props.title     The title.
- * @return {Element}                 The MediaText component.
+ * @param  {object}  props               MediaText component props.
+ * @param  {string}  props.body          The body text.
+ * @param  {Element} props.children      The child elements.
+ * @param  {string}  props.className     The className.
+ * @param  {object}  props.cta           The cta object with text and url strings.
+ * @param  {string}  props.id            Optional element ID.
+ * @param  {object}  props.image         The image object with url and alt text.
+ * @param  {boolean} props.mediaLeft     Whether to show media on the left of the text.
+ * @param  {boolean} props.stackOnMobile Whether to stack media and text on mobile.
+ * @param  {object}  props.style         Custom media text styles.
+ * @param  {string}  props.title         The title.
+ * @return {Element}                     The MediaText component.
  */
 export default function MediaText({
   body,
@@ -28,6 +29,7 @@ export default function MediaText({
   id,
   image,
   mediaLeft,
+  stackOnMobile,
   style,
   title
 }) {
@@ -45,7 +47,8 @@ export default function MediaText({
       className={cn(
         styles.mediaText,
         mediaLeft ? styles.mediaLeft : null,
-        className
+        className,
+        !stackOnMobile ? styles.noStack : null
       )}
       style={style}
     >
@@ -98,6 +101,7 @@ MediaText.propTypes = {
     alt: PropTypes.string
   }),
   mediaLeft: PropTypes.bool,
+  stackOnMobile: PropTypes.bool,
   style: PropTypes.shape({
     background: PropTypes.string,
     backgroundColor: PropTypes.string,

--- a/components/organisms/MediaText/MediaText.js
+++ b/components/organisms/MediaText/MediaText.js
@@ -47,6 +47,13 @@ export default function MediaText({
     }
   })
 
+  const imageFillStyle = !imageFill
+    ? null
+    : {
+        backgroundImage: `url(${image?.url || ''})`,
+        backgroundPosition: `${focalPoint.x} ${focalPoint.y}`
+      }
+
   return (
     <section
       id={id}
@@ -81,13 +88,7 @@ export default function MediaText({
           </>
         )}
       </div>
-      <div
-        className={styles.media}
-        style={{
-          backgroundImage: `url(${image?.url || ''})`,
-          backgroundPosition: `${focalPoint.x} ${focalPoint.y}`
-        }}
-      >
+      <div className={styles.media} style={imageFillStyle}>
         {image && image.url && (
           <DisplayImage
             className={styles.imageWrap}

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -1,5 +1,5 @@
 .mediaText {
-  @apply md:grid md:grid-cols-12 mb-12;
+  @apply md:grid md:grid-cols-12 mb-12 rounded;
 
   &.noStack {
     @apply grid grid-cols-12;
@@ -30,13 +30,13 @@
     grid-column: 2;
 
     & .imageWrap {
-      @apply relative h-0 w-full bg-opacity-20 mb-0;
+      @apply relative h-0 w-full rounded bg-opacity-20 mb-0;
 
       padding-top: 67.58%; /* Aspect ratio box - https://css-tricks.com/aspect-ratio-boxes */
     }
 
     & img {
-      @apply absolute top-0 left-0 w-full h-full object-cover rounded-none;
+      @apply absolute top-0 left-0 w-full h-full object-cover rounded;
     }
   }
 

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -58,13 +58,15 @@
   }
 
   &.alignTop {
-    & .text {
+    & .text,
+    & .media {
       @apply justify-start;
     }
   }
 
   &.alignBottom {
-    & .text {
+    & .text,
+    & .media {
       @apply justify-end;
     }
   }
@@ -72,8 +74,6 @@
   &.imageFill {
     & .media {
       @apply h-full max-w-full rounded;
-
-      min-height: 16rem;
 
       & .imageWrap {
         @apply pt-0;

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -4,10 +4,14 @@
   & .text,
   & .media {
     @apply col-span-6 flex flex-col items-start justify-center;
+
+    grid-row: 1;
   }
 
   & .text {
     @apply items-start pl-8 pr-8;
+
+    grid-column: 1;
 
     & .title {
       @apply mb-8;
@@ -19,6 +23,8 @@
   }
 
   & .media {
+    grid-column: 2;
+
     & .imageWrap {
       @apply relative h-0 w-full bg-opacity-20 mb-0;
 
@@ -32,11 +38,13 @@
 
   &.mediaLeft {
     & .media {
-      grid-row-start: 1;
+      grid-column: 1;
     }
 
     & .text {
       @apply items-end;
+
+      grid-column: 2;
 
       & .body {
         @apply text-right;

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -1,6 +1,10 @@
 .mediaText {
   @apply md:grid md:grid-cols-12 mb-12;
 
+  &.noStack {
+    @apply grid grid-cols-12;
+  }
+
   & .text,
   & .media {
     @apply col-span-6 flex flex-col items-start justify-center;

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -71,7 +71,7 @@
 
   &.imageFill {
     & .media {
-      @apply h-full max-w-full;
+      @apply h-full max-w-full rounded;
 
       min-height: 16rem;
 

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -7,7 +7,7 @@
   }
 
   & .text {
-    @apply items-start ml-8 mr-8;
+    @apply items-start pl-8 pr-8;
 
     & .title {
       @apply mb-8;

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -55,4 +55,16 @@
       }
     }
   }
+
+  &.alignTop {
+    & .text {
+      @apply justify-start;
+    }
+  }
+
+  &.alignBottom {
+    & .text {
+      @apply justify-end;
+    }
+  }
 }

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -20,13 +20,13 @@
 
   & .media {
     & .imageWrap {
-      @apply relative h-0 w-full rounded bg-opacity-20 mb-0;
+      @apply relative h-0 w-full bg-opacity-20 mb-0;
 
       padding-top: 67.58%; /* Aspect ratio box - https://css-tricks.com/aspect-ratio-boxes */
     }
 
     & img {
-      @apply absolute top-0 left-0 w-full h-full object-cover rounded;
+      @apply absolute top-0 left-0 w-full h-full object-cover rounded-none;
     }
   }
 

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -28,7 +28,6 @@
 
   & .media {
     grid-column: 2;
-    min-height: 15.5rem;
 
     & .imageWrap {
       @apply relative h-0 w-full rounded bg-opacity-20 mb-0;
@@ -74,6 +73,8 @@
   &.imageFill {
     & .media {
       @apply h-full max-w-full rounded;
+
+      min-height: 15.5rem;
 
       & .imageWrap {
         @apply pt-0;

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -1,5 +1,5 @@
 .mediaText {
-  @apply md:grid md:grid-cols-12 md:gap-16 mb-12;
+  @apply md:grid md:grid-cols-12 mb-12;
 
   & .text,
   & .media {
@@ -7,7 +7,7 @@
   }
 
   & .text {
-    @apply items-start;
+    @apply items-start ml-8 mr-8;
 
     & .title {
       @apply mb-8;

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -13,7 +13,7 @@
   }
 
   & .text {
-    @apply items-start pl-8 pr-8;
+    @apply items-start p-8;
 
     grid-column: 1;
 

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -20,7 +20,7 @@
 
   & .media {
     & .imageWrap {
-      @apply relative h-0 w-full rounded bg-opacity-20;
+      @apply relative h-0 w-full rounded bg-opacity-20 mb-0;
 
       padding-top: 67.58%; /* Aspect ratio box - https://css-tricks.com/aspect-ratio-boxes */
     }

--- a/components/organisms/MediaText/MediaText.module.css
+++ b/components/organisms/MediaText/MediaText.module.css
@@ -28,6 +28,7 @@
 
   & .media {
     grid-column: 2;
+    min-height: 15.5rem;
 
     & .imageWrap {
       @apply relative h-0 w-full rounded bg-opacity-20 mb-0;
@@ -65,6 +66,25 @@
   &.alignBottom {
     & .text {
       @apply justify-end;
+    }
+  }
+
+  &.imageFill {
+    & .media {
+      @apply h-full max-w-full;
+
+      min-height: 16rem;
+
+      & .imageWrap {
+        @apply pt-0;
+      }
+
+      & img {
+        clip: rect(0, 0, 0, 0);
+        height: 1px;
+        margin: -1px;
+        width: 1px;
+      }
     }
   }
 }


### PR DESCRIPTION
References #410

BE PR: https://github.com/WebDevStudios/wds-headless-wordpress/pull/38 - must be merged first

### Description

Adds additional attribute handling for Media & Text block & updates styling:
- Background (preset, custom, gradient preset, gradient custom) & text color (preset, custom)
- Media width
- Do/do not stack on mobile toggle
- Vertical text alignment
- Image fill & focal point

### Screenshot

### WP admin
![Screen Shot 2021-06-09 at 11 20 35 AM](https://user-images.githubusercontent.com/36422618/121400684-1cd2b800-c915-11eb-83d1-7f564f21b6a7.png)
![Screen Shot 2021-06-09 at 11 20 43 AM](https://user-images.githubusercontent.com/36422618/121400699-20663f00-c915-11eb-83cd-dbae979a1363.png)

### FE
![Screenshot 2021-06-09 at 11-38-14 410 Media Text Block Enhancements - Next js WordPress Starter](https://user-images.githubusercontent.com/36422618/121402583-4d1b5600-c917-11eb-91a7-aa5fb0cc511a.png)

### Verification

https://nextjs-wordpress-starter-fgouj5jjh-webdevstudios.vercel.app/blog/410-media-text-block-enhancements
