### PR TITLE
Fix broken image gallery images

### DIFF
--- a/components/molecules/ImageGallery/ImageGallery.js
+++ b/components/molecules/ImageGallery/ImageGallery.js
@@ -31,14 +31,14 @@ export default function ImageGallery({
           <div className={cn(styles.wrap, styles[`columns-${columns}`])}>
             {images.map((image, index) => {
               return (
-                <DisplayImage
-                  className={styles.imageWrap}
-                  key={index}
-                  alt={image.alt}
-                  id={image.id}
-                  imageMeta={{mediaItemUrl: image.url, altText: image.alt}}
-                  nextImageFill={true}
-                />
+                <div key={index} className={styles.imageWrap}>
+                  <DisplayImage
+                    alt={image.alt}
+                    id={image.id}
+                    url={image.url}
+                    nextImageFill={true}
+                  />
+                </div>
               )
             })}
           </div>


### PR DESCRIPTION
Closes N/A

### Description

Fix broken images in the ImageGallery component.

Images were broken for a couple of reasons after we switched to using `<DisplayImage />`.
* Moved `image.url` to the `url` prop
* Added `imageWrap` div as a wrapper to `<DisplayImage />` instead of as a className on `<DisplayImage />`

### Screenshot

BEFORE:
![ 2021-06-15 at 10 35 11 ](https://user-images.githubusercontent.com/12365909/122073406-62d0c580-cdc6-11eb-9bdd-53fa4575ee8a.png)

AFTER:
![ 2021-06-15 at 10 35 36 ](https://user-images.githubusercontent.com/12365909/122073424-66644c80-cdc6-11eb-8fea-f3d7fc513eb6.png)


### Verification

How will a stakeholder test this?

1. Run storybook
2. Verify that the ImageGallery component displays images
