### PR TITLE
feature/522-expand-menu-query

### DIFF
--- a/lib/wordpress/_query-partials/allMenus.js
+++ b/lib/wordpress/_query-partials/allMenus.js
@@ -3,7 +3,7 @@ const allMenus = `
   menus {
     nodes {
       locations
-      menuItems {
+      menuItems(first: 100) {
         nodes {
           id
           parentId


### PR DESCRIPTION
Closes #522 

### Description

Updates the menu query to retrieve up to 100 menu items instead of the default 10 (should cover all _reasonably_-sized menus).

### Screenshot

![Screen Shot 2021-06-16 at 12 26 40 PM](https://user-images.githubusercontent.com/36422618/122272927-1e185d80-ce9e-11eb-867b-9d7e647b27fb.png)

### Verification

https://nextjs-wordpress-starter-lfijry1qg-webdevstudios.vercel.app/
- all menu items [defined in WP admin](https://nextjsdevstart.wpengine.com/wp-admin/nav-menus.php) should display
