### PR TITLE
Feature/dependabot 2021 07 19

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,7 +15,8 @@ module.exports = {
     '@storybook/addon-a11y',
     '@storybook/addon-essentials',
     '@storybook/addon-links',
-    'storybook-css-modules-preset'
+    'storybook-css-modules-preset',
+    'storybook-addon-apollo-client'
   ],
   webpackFinal: async (config) => {
     // Enable @ symbol aliases.

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,20 +1,8 @@
 import {INITIAL_VIEWPORTS} from '@storybook/addon-viewport'
-import {addDecorator} from '@storybook/react'
+import {RouterContext} from 'next/dist/next-server/lib/router-context'
 import * as nextImage from 'next/image'
-import {withNextRouter} from 'storybook-addon-next-router'
 import '../styles/demo.css'
 import '../styles/index.css'
-
-/**
- * Enable Next.js <Link /> component usage.
- *
- * @see https://storybook.js.org/addons/storybook-addon-next-router
- */
-addDecorator(
-  withNextRouter({
-    path: '/'
-  })
-)
 
 /**
  * Enable Next.js <Image /> component usage.
@@ -69,6 +57,9 @@ const customViewports = {
 
 export const parameters = {
   actions: {argTypesRegex: '^on[A-Z].*'},
+  nextRouter: {
+    Provider: RouterContext.Provider
+  },
   viewport: {
     viewports: {
       ...customViewports,

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@testing-library/react": "^12.0.0",
         "algoliasearch": "^4.10.3",
         "apollo-link-rest": "^0.8.0-beta.0",
-        "autoprefixer": "^10.3.0",
+        "autoprefixer": "^10.3.1",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.2",
         "dayjs": "^1.10.6",
@@ -10034,9 +10034,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.0.tgz",
-      "integrity": "sha512-BzVzdjs47nT3MphTddr8eSsPVEIUCF96X6iC8V5iEB8RtxrU+ybtdhHV5rsqRqOsoyh/acQaYs7YupHPUECgmg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
+      "integrity": "sha512-L8AmtKzdiRyYg7BUXJTzigmhbQRCXFKz6SA1Lqo0+AR2FBbQ4aTAPFSDlOutnFkjhiz8my4agGXog1xlMjPJ6A==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.16.6",
@@ -41856,9 +41856,9 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.0.tgz",
-      "integrity": "sha512-BzVzdjs47nT3MphTddr8eSsPVEIUCF96X6iC8V5iEB8RtxrU+ybtdhHV5rsqRqOsoyh/acQaYs7YupHPUECgmg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
+      "integrity": "sha512-L8AmtKzdiRyYg7BUXJTzigmhbQRCXFKz6SA1Lqo0+AR2FBbQ4aTAPFSDlOutnFkjhiz8my4agGXog1xlMjPJ6A==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "markdownlint": "^0.23.1",
         "markdownlint-cli": "^0.27.1",
         "next-seo": "^4.26.0",
-        "next-sitemap": "^1.6.133",
+        "next-sitemap": "^1.6.140",
         "postcss": "^8.3.5",
         "postcss-flexbugs-fixes": "5.0.2",
         "postcss-preset-env": "^6.7.0",
@@ -23575,9 +23575,9 @@
       }
     },
     "node_modules/next-sitemap": {
-      "version": "1.6.133",
-      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-1.6.133.tgz",
-      "integrity": "sha512-AG4BIXoVO+Nl0nyIYCuz/Vh7Vtn0BO0Lc8ssr3YWiFQFXqHTdKVHUXNP3ZSekmT32BjcMgWtpyoiEAmpXty0ZA==",
+      "version": "1.6.140",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-1.6.140.tgz",
+      "integrity": "sha512-VTOQMae/nDLBRGBHnkmGoIsArymlOpJWkZUDvPapktF4QX2U7yvwHIHe7V7amqV2gE2xiDYgd0ayXOBBGuFHog==",
       "dev": true,
       "dependencies": {
         "@corex/deepmerge": "^2.6.20",
@@ -52568,9 +52568,9 @@
       "dev": true
     },
     "next-sitemap": {
-      "version": "1.6.133",
-      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-1.6.133.tgz",
-      "integrity": "sha512-AG4BIXoVO+Nl0nyIYCuz/Vh7Vtn0BO0Lc8ssr3YWiFQFXqHTdKVHUXNP3ZSekmT32BjcMgWtpyoiEAmpXty0ZA==",
+      "version": "1.6.140",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-1.6.140.tgz",
+      "integrity": "sha512-VTOQMae/nDLBRGBHnkmGoIsArymlOpJWkZUDvPapktF4QX2U7yvwHIHe7V7amqV2gE2xiDYgd0ayXOBBGuFHog==",
       "dev": true,
       "requires": {
         "@corex/deepmerge": "^2.6.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "babel-loader": "^8.2.2",
         "dayjs": "^1.10.6",
         "deepmerge": "^4.2.2",
-        "eslint": "^7.30.0",
+        "eslint": "^7.30.1",
         "eslint-config-next": "^11.0.1",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-jest": "^24.3.6",
@@ -2308,9 +2308,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
-      "integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -2328,9 +2328,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -14147,13 +14147,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
-      "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
+      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.2",
+        "@eslint/eslintrc": "^0.4.3",
         "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -36017,9 +36017,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
-      "integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -36034,9 +36034,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.9.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-          "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+          "version": "13.10.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+          "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -45134,13 +45134,13 @@
       }
     },
     "eslint": {
-      "version": "7.30.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
-      "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
+      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.2",
+        "@eslint/eslintrc": "^0.4.3",
         "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-config-next": "^11.0.1",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-jest": "^24.3.6",
-        "eslint-plugin-jsdoc": "^35.4.3",
+        "eslint-plugin-jsdoc": "^35.4.5",
         "eslint-plugin-prettier": "^3.4.0",
         "formidable": "^1.2.2",
         "formik": "^2.2.9",
@@ -14620,9 +14620,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "35.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-35.4.3.tgz",
-      "integrity": "sha512-hBEn+VNjVX0IKoZ2OdZs0Z1fU8CqZkBSzLqD8ZpwZEamrdi2TUgKvujvETe8gXYQ/67hpRtbR5iPFTgmWpRevw==",
+      "version": "35.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-35.4.5.tgz",
+      "integrity": "sha512-CguI9uhIJoihCsW5WTUY9xX2w9EpovmmHCz/JzAevC7Fcop+wyJLDjzaBnTh2LlSJvG9qVfkr7OJ+9i4cv1Kzg==",
       "dev": true,
       "dependencies": {
         "@es-joy/jsdoccomment": "^0.9.0-alpha.1",
@@ -45589,9 +45589,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "35.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-35.4.3.tgz",
-      "integrity": "sha512-hBEn+VNjVX0IKoZ2OdZs0Z1fU8CqZkBSzLqD8ZpwZEamrdi2TUgKvujvETe8gXYQ/67hpRtbR5iPFTgmWpRevw==",
+      "version": "35.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-35.4.5.tgz",
+      "integrity": "sha512-CguI9uhIJoihCsW5WTUY9xX2w9EpovmmHCz/JzAevC7Fcop+wyJLDjzaBnTh2LlSJvG9qVfkr7OJ+9i4cv1Kzg==",
       "dev": true,
       "requires": {
         "@es-joy/jsdoccomment": "^0.9.0-alpha.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "react-syntax-highlighter": "^15.4.3",
         "react-twitter-embed": "^3.0.3",
         "rimraf": "^3.0.2",
-        "storybook-addon-next-router": "^2.0.4",
+        "storybook-addon-next-router": "^3.0.5",
         "storybook-css-modules-preset": "^1.1.1",
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^22.0.0",
@@ -30306,9 +30306,9 @@
       "dev": true
     },
     "node_modules/storybook-addon-next-router": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/storybook-addon-next-router/-/storybook-addon-next-router-2.0.4.tgz",
-      "integrity": "sha512-PAlAVA2joJC36r2uRU7pL5tNPqcOlcgJNuWyyiPAG6f/sptBK4EdOKUUdU0X9NBVV6BCkiwbLH/kkPmWYRxiFw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/storybook-addon-next-router/-/storybook-addon-next-router-3.0.5.tgz",
+      "integrity": "sha512-GgXhKRBh6nAFhQu9mtaupgdBizD57Ld42o3MFUrs6y1pKEq0/FTSy585o7u46gdEYx1IH8X48dl4qy3iBcwl8w==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -30316,7 +30316,8 @@
       "peerDependencies": {
         "@storybook/addon-actions": "^6.0.0",
         "@storybook/addons": "^6.0.0",
-        "next": "^9.0.0 || ^10.0.0",
+        "@storybook/client-api": "^6.0.0",
+        "next": "^9.0.0 || ^10.0.0 || ^11.0.0",
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
       }
@@ -57668,9 +57669,9 @@
       "dev": true
     },
     "storybook-addon-next-router": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/storybook-addon-next-router/-/storybook-addon-next-router-2.0.4.tgz",
-      "integrity": "sha512-PAlAVA2joJC36r2uRU7pL5tNPqcOlcgJNuWyyiPAG6f/sptBK4EdOKUUdU0X9NBVV6BCkiwbLH/kkPmWYRxiFw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/storybook-addon-next-router/-/storybook-addon-next-router-3.0.5.tgz",
+      "integrity": "sha512-GgXhKRBh6nAFhQu9mtaupgdBizD57Ld42o3MFUrs6y1pKEq0/FTSy585o7u46gdEYx1IH8X48dl4qy3iBcwl8w==",
       "dev": true
     },
     "storybook-addon-outline": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "markdownlint": "^0.23.1",
     "markdownlint-cli": "^0.27.1",
     "next-seo": "^4.26.0",
-    "next-sitemap": "^1.6.133",
+    "next-sitemap": "^1.6.140",
     "postcss": "^8.3.5",
     "postcss-flexbugs-fixes": "5.0.2",
     "postcss-preset-env": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "react-syntax-highlighter": "^15.4.3",
     "react-twitter-embed": "^3.0.3",
     "rimraf": "^3.0.2",
-    "storybook-addon-next-router": "^2.0.4",
+    "storybook-addon-next-router": "^3.0.5",
     "storybook-css-modules-preset": "^1.1.1",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@testing-library/react": "^12.0.0",
     "algoliasearch": "^4.10.3",
     "apollo-link-rest": "^0.8.0-beta.0",
-    "autoprefixer": "^10.3.0",
+    "autoprefixer": "^10.3.1",
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.2.2",
     "dayjs": "^1.10.6",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-config-next": "^11.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jest": "^24.3.6",
-    "eslint-plugin-jsdoc": "^35.4.3",
+    "eslint-plugin-jsdoc": "^35.4.5",
     "eslint-plugin-prettier": "^3.4.0",
     "formidable": "^1.2.2",
     "formik": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "babel-loader": "^8.2.2",
     "dayjs": "^1.10.6",
     "deepmerge": "^4.2.2",
-    "eslint": "^7.30.0",
+    "eslint": "^7.30.1",
     "eslint-config-next": "^11.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jest": "^24.3.6",


### PR DESCRIPTION
Closes #562
Closes #563
Closes #564 
Closes #565 
Closes #566

### Link

(Develop Branch)
https://nextjs-wordpress-starter-pzdn18hv4-webdevstudios.vercel.app/

### Description

This PR updates the following Node dependencies:

```bash
 autoprefixer                  ^10.3.0  →   ^10.3.1     
 eslint                        ^7.30.0  →   ^7.31.0     
 eslint-plugin-jsdoc           ^35.4.3  →   ^35.4.5     
 next-sitemap                 ^1.6.133  →  ^1.6.140     
 storybook-addon-next-router    ^2.0.4  →    ^3.0.5 
```

> Note: Storybook Addon Next Router's config may need to be updated when Next.js 11.2 is released. See https://storybook.js.org/addons/storybook-addon-next-router

### Screenshot

Frontend
![screenshot](https://dl.dropbox.com/s/aoelz4gancocy5q/Screen%20Shot%202021-07-19%20at%208.23.00%20AM.png?dl=0)

Storybook
![screenshot](https://dl.dropbox.com/s/kuqf30vw11nfjbm/Screen%20Shot%202021-07-19%20at%207.59.25%20AM.png?dl=0)

### Verification

How will a stakeholder test this?

1. `gh pr checkout 567`
2. `npm i --legacy-peer-deps`
3. `npm run build && npm start`
4. Verify the frontend loads
5. `npm run storybook`
6. Verify Storybook opens and looks correct
