### PR TITLE
Feature/dependabot 2021 08 23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@storybook/react": "^6.3.7",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.0.0",
-        "algoliasearch": "^4.10.3",
+        "algoliasearch": "^4.10.4",
         "apollo-link-rest": "^0.8.0-beta.0",
         "autoprefixer": "^10.3.1",
         "babel-jest": "^27.0.6",
@@ -74,132 +74,132 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.3.tgz",
-      "integrity": "sha512-TD1N7zg5lb56/PLjjD4bBl2eccEvVHhC7yfgFu2r9k5tf+gvbGxEZ3NhRZVKu2MObUIcEy2VR4LVLxOQu45Hlg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.4.tgz",
+      "integrity": "sha512-oNCRQWI9cTYqNkyt+lelkqF5Z3sQNSJ2OT9tK5w0587IJNWqkzZzqipJyWHZv2sWyBbOboDrwZfZUcik3y0Qrg==",
       "dev": true,
       "dependencies": {
-        "@algolia/cache-common": "4.10.3"
+        "@algolia/cache-common": "4.10.4"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.3.tgz",
-      "integrity": "sha512-q13cPPUmtf8a2suBC4kySSr97EyulSXuxUkn7l1tZUCX/k1y5KNheMp8npBy8Kc8gPPmHpacxddRSfOncjiKFw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.4.tgz",
+      "integrity": "sha512-R2Sbg8zvVMsxFDKWQYAZD1cQIEO6J00dZFjFfYDMTH+r/t2CCOZal2EFGnHl7FcgTIEUsSrNJUzLefL8NM8/iA==",
       "dev": true
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.3.tgz",
-      "integrity": "sha512-JhPajhOXAjUP+TZrZTh6KJpF5VKTKyWK2aR1cD8NtrcVHwfGS7fTyfXfVm5BqBqkD9U0gVvufUt/mVyI80aZww==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.4.tgz",
+      "integrity": "sha512-ReQnhekfAvYFRu2odShmMxPM2OcRjSK1Atncam2HSu7Zt/51gtQp6WJMm7K+Mb3y+mT+ckBbOTamv/uTREcu2A==",
       "dev": true,
       "dependencies": {
-        "@algolia/cache-common": "4.10.3"
+        "@algolia/cache-common": "4.10.4"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.3.tgz",
-      "integrity": "sha512-S/IsJB4s+e1xYctdpW3nAbwrR2y3pjSo9X21fJGoiGeIpTRdvQG7nydgsLkhnhcgAdLnmqBapYyAqMGmlcyOkg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.4.tgz",
+      "integrity": "sha512-Wtr91lXidDh5niXL0LPWxCluRdKA2CDpE2O/RKc9uMNDYCzCOkAxF2CcUuIpEW0IceO0D3d8n/TLuuKOIk2mww==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "4.10.3",
-        "@algolia/client-search": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/client-common": "4.10.4",
+        "@algolia/client-search": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.3.tgz",
-      "integrity": "sha512-vlHTbBqJktRgclh3v7bPQLfZvFIqY4erNFIZA5C7nisCj9oLeTgzefoUrr+R90+I+XjfoLxnmoeigS1Z1yg1vw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.4.tgz",
+      "integrity": "sha512-CNOqWwq735i2kDh4DWk9Y4AN4mPIYOOec83xeWRnlSTfoL6DbLWVZTNBHi7Mi97h3prKVpr/Zm4f46RPrTYSsA==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "4.10.3",
-        "@algolia/client-search": "4.10.3",
-        "@algolia/requester-common": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/client-common": "4.10.4",
+        "@algolia/client-search": "4.10.4",
+        "@algolia/requester-common": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.3.tgz",
-      "integrity": "sha512-uFyP2Z14jG2hsFRbAoavna6oJf4NTXaSDAZgouZUZlHlBp5elM38sjNeA5HR9/D9J/GjwaB1SgB7iUiIWYBB4w==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.4.tgz",
+      "integrity": "sha512-O5GcD/7JW7eLlLPc2AUGUHmWP95JZthivpiOmwloAVR1DFvgKZL3+1e3/e1wederPA3ETvz80++aL+6yPRhb8w==",
       "dev": true,
       "dependencies": {
-        "@algolia/requester-common": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/requester-common": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.3.tgz",
-      "integrity": "sha512-NS7Nx8EJ/nduGXT8CFo5z7kLF0jnFehTP3eC+z+GOEESH3rrs7uR12IZHxv5QhQswZa9vl925zCOZDcDVoENCg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.4.tgz",
+      "integrity": "sha512-n5lb4DXLhk0rbCBSE2TgjKko+NCX0/lNBCSTszdanznkdA8NaHnOdy0/LvDoXh2ZYAMJx2etZvfWLYcSLO8cGQ==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "4.10.3",
-        "@algolia/requester-common": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/client-common": "4.10.4",
+        "@algolia/requester-common": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.3.tgz",
-      "integrity": "sha512-Zwnp2G94IrNFKWCG/k7epI5UswRkPvL9FCt7/slXe2bkjP2y/HA37gzRn+9tXoLVRwd7gBzrtOA4jFKIyjrtVw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.4.tgz",
+      "integrity": "sha512-qqSKogn85YTub8g01N4tcctsowbxq+QJzzzHSQA0+j4Pw93CguinDpX6mU/WbLIZIu2eaTeAQ7pORual3Li0yA==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "4.10.3",
-        "@algolia/requester-common": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/client-common": "4.10.4",
+        "@algolia/requester-common": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.3.tgz",
-      "integrity": "sha512-M6xi+qov2bkgg1H9e1Qtvq/E/eKsGcgz8RBbXNzqPIYoDGZNkv+b3b8YMo3dxd4Wd6M24HU1iqF3kmr1LaXndg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.4.tgz",
+      "integrity": "sha512-B4D6HqS2TDcf6S8YEr9cFm8S7eswIniojC8IFoCtlfMxhCj2OM70rH1eqfY2VQy/KPY1txYPdMPk8AG8685fHg==",
       "dev": true
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.3.tgz",
-      "integrity": "sha512-vVgRI7b4PHjgBdRkv/cRz490twvkLoGdpC4VYzIouSrKj8SIVLRhey3qgXk7oQXi3xoxVAv6NrklHfpO8Bpx0w==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.4.tgz",
+      "integrity": "sha512-217KiWZ66BcQ5begHhD+h8mNTjOHvTmUYV203pXteExOgfAm/gzQ4GzzAwXVAhCID2tzRDObfDq8M3BCMp8NPA==",
       "dev": true,
       "dependencies": {
-        "@algolia/logger-common": "4.10.3"
+        "@algolia/logger-common": "4.10.4"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.3.tgz",
-      "integrity": "sha512-4WIk1zreFbc1EF6+gsfBTQvwSNjWc20zJAAExRWql/Jq5yfVHmwOqi/CajA53/cXKFBqo80DAMRvOiwP+hOLYw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.4.tgz",
+      "integrity": "sha512-a8sEt9WQeolA/ZCSfhd2ImH+8v7o45359Omn2iBXzB3+UD/fo1jOFcDgyX35AusXw8pNtDI/Jd4n0vBYJvtSWg==",
       "dev": true,
       "dependencies": {
-        "@algolia/requester-common": "4.10.3"
+        "@algolia/requester-common": "4.10.4"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.3.tgz",
-      "integrity": "sha512-PNfLHmg0Hujugs3rx55uz/ifv7b9HVdSFQDb2hj0O5xZaBEuQCNOXC6COrXR8+9VEfqp2swpg7zwgtqFxh+BtQ==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.4.tgz",
+      "integrity": "sha512-RkAxkX/z8DAHUGg0vtZkY/lZXBPc/aEUf/DmWPp2dspAiCp1ekYlyf+qLNwOwEHMu+Q6nm+meStpAUl0BpsNVg==",
       "dev": true
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.3.tgz",
-      "integrity": "sha512-A9ZcGfEvgqf0luJApdNcIhsRh6MShn2zn2tbjwjGG1joF81w+HUY+BWuLZn56vGwAA9ZB9n00IoJJpxibbfofg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.4.tgz",
+      "integrity": "sha512-iixy8GOrj0A4sIQX2Q0GChc1z3iM6LF8fJNXVXG629hbXlssEECAl8wO3+6bqAOgbCLiYeY9Aj3QsJyA6vJ4Iw==",
       "dev": true,
       "dependencies": {
-        "@algolia/requester-common": "4.10.3"
+        "@algolia/requester-common": "4.10.4"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.3.tgz",
-      "integrity": "sha512-n1lRyKDbrckbMEgm7QXtj3nEWUuzA3aKLzVQ43/F/RCFib15j4IwtmYhXR6OIBRSc7+T0Hm48S0J6F+HeYCQkw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.4.tgz",
+      "integrity": "sha512-I60q9+4mYo3D9qIsUYaxU8ZukJVG/DWn1FBAeB5bW9c6/+chmppYJ5CJd/ZvKYEWd7ESwaRrrceYev94O4VrWw==",
       "dev": true,
       "dependencies": {
-        "@algolia/cache-common": "4.10.3",
-        "@algolia/logger-common": "4.10.3",
-        "@algolia/requester-common": "4.10.3"
+        "@algolia/cache-common": "4.10.4",
+        "@algolia/logger-common": "4.10.4",
+        "@algolia/requester-common": "4.10.4"
       }
     },
     "node_modules/@apollo/client": {
@@ -8964,25 +8964,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.3.tgz",
-      "integrity": "sha512-OLY0AWlPKGLbSaw14ivMB7BT5fPdp8VdzY4L8FtzZnqmLKsyes24cltGlf7/X96ACkYEcT390SReCDt/9SUIRg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.4.tgz",
+      "integrity": "sha512-noZ59PZYyYJVsm78YEo6EXH5DgaU0jSKf17xxJ3q9WtpBkmiaNk5b53mSJFsAI3c5gMOWgXM4+4o1EEaCbXXGg==",
       "dev": true,
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.10.3",
-        "@algolia/cache-common": "4.10.3",
-        "@algolia/cache-in-memory": "4.10.3",
-        "@algolia/client-account": "4.10.3",
-        "@algolia/client-analytics": "4.10.3",
-        "@algolia/client-common": "4.10.3",
-        "@algolia/client-personalization": "4.10.3",
-        "@algolia/client-search": "4.10.3",
-        "@algolia/logger-common": "4.10.3",
-        "@algolia/logger-console": "4.10.3",
-        "@algolia/requester-browser-xhr": "4.10.3",
-        "@algolia/requester-common": "4.10.3",
-        "@algolia/requester-node-http": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/cache-browser-local-storage": "4.10.4",
+        "@algolia/cache-common": "4.10.4",
+        "@algolia/cache-in-memory": "4.10.4",
+        "@algolia/client-account": "4.10.4",
+        "@algolia/client-analytics": "4.10.4",
+        "@algolia/client-common": "4.10.4",
+        "@algolia/client-personalization": "4.10.4",
+        "@algolia/client-search": "4.10.4",
+        "@algolia/logger-common": "4.10.4",
+        "@algolia/logger-console": "4.10.4",
+        "@algolia/requester-browser-xhr": "4.10.4",
+        "@algolia/requester-common": "4.10.4",
+        "@algolia/requester-node-http": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "node_modules/algoliasearch-helper": {
@@ -33680,132 +33680,132 @@
   },
   "dependencies": {
     "@algolia/cache-browser-local-storage": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.3.tgz",
-      "integrity": "sha512-TD1N7zg5lb56/PLjjD4bBl2eccEvVHhC7yfgFu2r9k5tf+gvbGxEZ3NhRZVKu2MObUIcEy2VR4LVLxOQu45Hlg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.4.tgz",
+      "integrity": "sha512-oNCRQWI9cTYqNkyt+lelkqF5Z3sQNSJ2OT9tK5w0587IJNWqkzZzqipJyWHZv2sWyBbOboDrwZfZUcik3y0Qrg==",
       "dev": true,
       "requires": {
-        "@algolia/cache-common": "4.10.3"
+        "@algolia/cache-common": "4.10.4"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.3.tgz",
-      "integrity": "sha512-q13cPPUmtf8a2suBC4kySSr97EyulSXuxUkn7l1tZUCX/k1y5KNheMp8npBy8Kc8gPPmHpacxddRSfOncjiKFw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.4.tgz",
+      "integrity": "sha512-R2Sbg8zvVMsxFDKWQYAZD1cQIEO6J00dZFjFfYDMTH+r/t2CCOZal2EFGnHl7FcgTIEUsSrNJUzLefL8NM8/iA==",
       "dev": true
     },
     "@algolia/cache-in-memory": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.3.tgz",
-      "integrity": "sha512-JhPajhOXAjUP+TZrZTh6KJpF5VKTKyWK2aR1cD8NtrcVHwfGS7fTyfXfVm5BqBqkD9U0gVvufUt/mVyI80aZww==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.4.tgz",
+      "integrity": "sha512-ReQnhekfAvYFRu2odShmMxPM2OcRjSK1Atncam2HSu7Zt/51gtQp6WJMm7K+Mb3y+mT+ckBbOTamv/uTREcu2A==",
       "dev": true,
       "requires": {
-        "@algolia/cache-common": "4.10.3"
+        "@algolia/cache-common": "4.10.4"
       }
     },
     "@algolia/client-account": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.3.tgz",
-      "integrity": "sha512-S/IsJB4s+e1xYctdpW3nAbwrR2y3pjSo9X21fJGoiGeIpTRdvQG7nydgsLkhnhcgAdLnmqBapYyAqMGmlcyOkg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.4.tgz",
+      "integrity": "sha512-Wtr91lXidDh5niXL0LPWxCluRdKA2CDpE2O/RKc9uMNDYCzCOkAxF2CcUuIpEW0IceO0D3d8n/TLuuKOIk2mww==",
       "dev": true,
       "requires": {
-        "@algolia/client-common": "4.10.3",
-        "@algolia/client-search": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/client-common": "4.10.4",
+        "@algolia/client-search": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.3.tgz",
-      "integrity": "sha512-vlHTbBqJktRgclh3v7bPQLfZvFIqY4erNFIZA5C7nisCj9oLeTgzefoUrr+R90+I+XjfoLxnmoeigS1Z1yg1vw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.4.tgz",
+      "integrity": "sha512-CNOqWwq735i2kDh4DWk9Y4AN4mPIYOOec83xeWRnlSTfoL6DbLWVZTNBHi7Mi97h3prKVpr/Zm4f46RPrTYSsA==",
       "dev": true,
       "requires": {
-        "@algolia/client-common": "4.10.3",
-        "@algolia/client-search": "4.10.3",
-        "@algolia/requester-common": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/client-common": "4.10.4",
+        "@algolia/client-search": "4.10.4",
+        "@algolia/requester-common": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "@algolia/client-common": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.3.tgz",
-      "integrity": "sha512-uFyP2Z14jG2hsFRbAoavna6oJf4NTXaSDAZgouZUZlHlBp5elM38sjNeA5HR9/D9J/GjwaB1SgB7iUiIWYBB4w==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.4.tgz",
+      "integrity": "sha512-O5GcD/7JW7eLlLPc2AUGUHmWP95JZthivpiOmwloAVR1DFvgKZL3+1e3/e1wederPA3ETvz80++aL+6yPRhb8w==",
       "dev": true,
       "requires": {
-        "@algolia/requester-common": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/requester-common": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.3.tgz",
-      "integrity": "sha512-NS7Nx8EJ/nduGXT8CFo5z7kLF0jnFehTP3eC+z+GOEESH3rrs7uR12IZHxv5QhQswZa9vl925zCOZDcDVoENCg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.4.tgz",
+      "integrity": "sha512-n5lb4DXLhk0rbCBSE2TgjKko+NCX0/lNBCSTszdanznkdA8NaHnOdy0/LvDoXh2ZYAMJx2etZvfWLYcSLO8cGQ==",
       "dev": true,
       "requires": {
-        "@algolia/client-common": "4.10.3",
-        "@algolia/requester-common": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/client-common": "4.10.4",
+        "@algolia/requester-common": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "@algolia/client-search": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.3.tgz",
-      "integrity": "sha512-Zwnp2G94IrNFKWCG/k7epI5UswRkPvL9FCt7/slXe2bkjP2y/HA37gzRn+9tXoLVRwd7gBzrtOA4jFKIyjrtVw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.4.tgz",
+      "integrity": "sha512-qqSKogn85YTub8g01N4tcctsowbxq+QJzzzHSQA0+j4Pw93CguinDpX6mU/WbLIZIu2eaTeAQ7pORual3Li0yA==",
       "dev": true,
       "requires": {
-        "@algolia/client-common": "4.10.3",
-        "@algolia/requester-common": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/client-common": "4.10.4",
+        "@algolia/requester-common": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "@algolia/logger-common": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.3.tgz",
-      "integrity": "sha512-M6xi+qov2bkgg1H9e1Qtvq/E/eKsGcgz8RBbXNzqPIYoDGZNkv+b3b8YMo3dxd4Wd6M24HU1iqF3kmr1LaXndg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.4.tgz",
+      "integrity": "sha512-B4D6HqS2TDcf6S8YEr9cFm8S7eswIniojC8IFoCtlfMxhCj2OM70rH1eqfY2VQy/KPY1txYPdMPk8AG8685fHg==",
       "dev": true
     },
     "@algolia/logger-console": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.3.tgz",
-      "integrity": "sha512-vVgRI7b4PHjgBdRkv/cRz490twvkLoGdpC4VYzIouSrKj8SIVLRhey3qgXk7oQXi3xoxVAv6NrklHfpO8Bpx0w==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.4.tgz",
+      "integrity": "sha512-217KiWZ66BcQ5begHhD+h8mNTjOHvTmUYV203pXteExOgfAm/gzQ4GzzAwXVAhCID2tzRDObfDq8M3BCMp8NPA==",
       "dev": true,
       "requires": {
-        "@algolia/logger-common": "4.10.3"
+        "@algolia/logger-common": "4.10.4"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.3.tgz",
-      "integrity": "sha512-4WIk1zreFbc1EF6+gsfBTQvwSNjWc20zJAAExRWql/Jq5yfVHmwOqi/CajA53/cXKFBqo80DAMRvOiwP+hOLYw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.4.tgz",
+      "integrity": "sha512-a8sEt9WQeolA/ZCSfhd2ImH+8v7o45359Omn2iBXzB3+UD/fo1jOFcDgyX35AusXw8pNtDI/Jd4n0vBYJvtSWg==",
       "dev": true,
       "requires": {
-        "@algolia/requester-common": "4.10.3"
+        "@algolia/requester-common": "4.10.4"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.3.tgz",
-      "integrity": "sha512-PNfLHmg0Hujugs3rx55uz/ifv7b9HVdSFQDb2hj0O5xZaBEuQCNOXC6COrXR8+9VEfqp2swpg7zwgtqFxh+BtQ==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.4.tgz",
+      "integrity": "sha512-RkAxkX/z8DAHUGg0vtZkY/lZXBPc/aEUf/DmWPp2dspAiCp1ekYlyf+qLNwOwEHMu+Q6nm+meStpAUl0BpsNVg==",
       "dev": true
     },
     "@algolia/requester-node-http": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.3.tgz",
-      "integrity": "sha512-A9ZcGfEvgqf0luJApdNcIhsRh6MShn2zn2tbjwjGG1joF81w+HUY+BWuLZn56vGwAA9ZB9n00IoJJpxibbfofg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.4.tgz",
+      "integrity": "sha512-iixy8GOrj0A4sIQX2Q0GChc1z3iM6LF8fJNXVXG629hbXlssEECAl8wO3+6bqAOgbCLiYeY9Aj3QsJyA6vJ4Iw==",
       "dev": true,
       "requires": {
-        "@algolia/requester-common": "4.10.3"
+        "@algolia/requester-common": "4.10.4"
       }
     },
     "@algolia/transporter": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.3.tgz",
-      "integrity": "sha512-n1lRyKDbrckbMEgm7QXtj3nEWUuzA3aKLzVQ43/F/RCFib15j4IwtmYhXR6OIBRSc7+T0Hm48S0J6F+HeYCQkw==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.4.tgz",
+      "integrity": "sha512-I60q9+4mYo3D9qIsUYaxU8ZukJVG/DWn1FBAeB5bW9c6/+chmppYJ5CJd/ZvKYEWd7ESwaRrrceYev94O4VrWw==",
       "dev": true,
       "requires": {
-        "@algolia/cache-common": "4.10.3",
-        "@algolia/logger-common": "4.10.3",
-        "@algolia/requester-common": "4.10.3"
+        "@algolia/cache-common": "4.10.4",
+        "@algolia/logger-common": "4.10.4",
+        "@algolia/requester-common": "4.10.4"
       }
     },
     "@apollo/client": {
@@ -40300,25 +40300,25 @@
       "dev": true
     },
     "algoliasearch": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.3.tgz",
-      "integrity": "sha512-OLY0AWlPKGLbSaw14ivMB7BT5fPdp8VdzY4L8FtzZnqmLKsyes24cltGlf7/X96ACkYEcT390SReCDt/9SUIRg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.4.tgz",
+      "integrity": "sha512-noZ59PZYyYJVsm78YEo6EXH5DgaU0jSKf17xxJ3q9WtpBkmiaNk5b53mSJFsAI3c5gMOWgXM4+4o1EEaCbXXGg==",
       "dev": true,
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.10.3",
-        "@algolia/cache-common": "4.10.3",
-        "@algolia/cache-in-memory": "4.10.3",
-        "@algolia/client-account": "4.10.3",
-        "@algolia/client-analytics": "4.10.3",
-        "@algolia/client-common": "4.10.3",
-        "@algolia/client-personalization": "4.10.3",
-        "@algolia/client-search": "4.10.3",
-        "@algolia/logger-common": "4.10.3",
-        "@algolia/logger-console": "4.10.3",
-        "@algolia/requester-browser-xhr": "4.10.3",
-        "@algolia/requester-common": "4.10.3",
-        "@algolia/requester-node-http": "4.10.3",
-        "@algolia/transporter": "4.10.3"
+        "@algolia/cache-browser-local-storage": "4.10.4",
+        "@algolia/cache-common": "4.10.4",
+        "@algolia/cache-in-memory": "4.10.4",
+        "@algolia/client-account": "4.10.4",
+        "@algolia/client-analytics": "4.10.4",
+        "@algolia/client-common": "4.10.4",
+        "@algolia/client-personalization": "4.10.4",
+        "@algolia/client-search": "4.10.4",
+        "@algolia/logger-common": "4.10.4",
+        "@algolia/logger-console": "4.10.4",
+        "@algolia/requester-browser-xhr": "4.10.4",
+        "@algolia/requester-common": "4.10.4",
+        "@algolia/requester-node-http": "4.10.4",
+        "@algolia/transporter": "4.10.4"
       }
     },
     "algoliasearch-helper": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-jest": "^24.4.0",
         "eslint-plugin-jsdoc": "^36.0.7",
-        "eslint-plugin-prettier": "^3.4.0",
+        "eslint-plugin-prettier": "^3.4.1",
         "formidable": "^1.2.2",
         "formik": "^2.2.9",
         "graphql": "^15.5.1",
@@ -14037,9 +14037,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
-      "integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
+      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
       "dev": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0"
@@ -44419,9 +44419,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
-      "integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
+      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "nextjs-wordpress-starter",
       "version": "1.0.0",
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -15,7 +16,7 @@
         "react-dom": "17.0.2"
       },
       "devDependencies": {
-        "@apollo/client": "^3.4.7",
+        "@apollo/client": "^3.4.8",
         "@arkweid/lefthook": "^0.7.6",
         "@babel/core": "^7.15.0",
         "@next/bundle-analyzer": "^11.1.0",
@@ -61,7 +62,6 @@
         "react-syntax-highlighter": "^15.4.4",
         "react-twitter-embed": "^3.0.3",
         "rimraf": "^3.0.2",
-        "storybook-addon-next-router": "^3.0.7",
         "storybook-css-modules-preset": "^1.1.1",
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^22.0.0",
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.7.tgz",
-      "integrity": "sha512-EmqGxXD8hr05cIFWJFwtGXifc+Lo8hTCEuiaQMtKknHszJfqIFXSxqP+H+eJnjfuoxH74aTSsZKtJlnE83Vt6w==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.8.tgz",
+      "integrity": "sha512-/cNqTSwc2Dw8q6FDDjdd30+yvhP7rI0Fvl3Hbro0lTtFuhzkevfNyQaI2jAiOrjU6Jc0RbanxULaNrX7UmvjSQ==",
       "dev": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.0.0",
@@ -29454,23 +29454,6 @@
       "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==",
       "dev": true
     },
-    "node_modules/storybook-addon-next-router": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/storybook-addon-next-router/-/storybook-addon-next-router-3.0.7.tgz",
-      "integrity": "sha512-D8cRPG5RwqVceHdaSeicaoJywKfwzdJHuwASLBaFdIfnMUAlCPmXjaYTGs3o5prKP2Mpdi5rpLCJMIaMBCdBeQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@storybook/addon-actions": "^6.0.0",
-        "@storybook/addons": "^6.0.0",
-        "@storybook/client-api": "^6.0.0",
-        "next": "^9.0.0 || ^10.0.0 || ^11.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
     "node_modules/storybook-addon-outline": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/storybook-addon-outline/-/storybook-addon-outline-1.4.1.tgz",
@@ -33826,9 +33809,9 @@
       }
     },
     "@apollo/client": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.7.tgz",
-      "integrity": "sha512-EmqGxXD8hr05cIFWJFwtGXifc+Lo8hTCEuiaQMtKknHszJfqIFXSxqP+H+eJnjfuoxH74aTSsZKtJlnE83Vt6w==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.8.tgz",
+      "integrity": "sha512-/cNqTSwc2Dw8q6FDDjdd30+yvhP7rI0Fvl3Hbro0lTtFuhzkevfNyQaI2jAiOrjU6Jc0RbanxULaNrX7UmvjSQ==",
       "dev": true,
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
@@ -56247,12 +56230,6 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.12.0.tgz",
       "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==",
-      "dev": true
-    },
-    "storybook-addon-next-router": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/storybook-addon-next-router/-/storybook-addon-next-router-3.0.7.tgz",
-      "integrity": "sha512-D8cRPG5RwqVceHdaSeicaoJywKfwzdJHuwASLBaFdIfnMUAlCPmXjaYTGs3o5prKP2Mpdi5rpLCJMIaMBCdBeQ==",
       "dev": true
     },
     "storybook-addon-outline": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "markdownlint": "^0.24.0",
         "markdownlint-cli": "^0.28.1",
         "next-seo": "^4.26.0",
-        "next-sitemap": "^1.6.157",
+        "next-sitemap": "^1.6.162",
         "postcss": "^8.3.6",
         "postcss-flexbugs-fixes": "5.0.2",
         "postcss-preset-env": "^6.7.0",
@@ -22422,12 +22422,12 @@
       }
     },
     "node_modules/next-sitemap": {
-      "version": "1.6.157",
-      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-1.6.157.tgz",
-      "integrity": "sha512-5aIGplbGj0vRsetVla1ZW+0CaRtFnDY9ffW8qqii/nAfOyFuBgaHgKS92TsuBPNzz7O0/7vz4x8jZXEoR9tg2w==",
+      "version": "1.6.162",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-1.6.162.tgz",
+      "integrity": "sha512-JHc10olNs3Dt89Qur4K3V29cKdM8sG0dg6sVTbsZAm2pzw/3d9AAhLiV614w7dCElovFwAl93V1fF/mgG5I48Q==",
       "dev": true,
       "dependencies": {
-        "@corex/deepmerge": "^2.6.20",
+        "@corex/deepmerge": "^2.6.34",
         "matcher": "^4.0.0",
         "minimist": "^1.2.5"
       },
@@ -50965,12 +50965,12 @@
       "dev": true
     },
     "next-sitemap": {
-      "version": "1.6.157",
-      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-1.6.157.tgz",
-      "integrity": "sha512-5aIGplbGj0vRsetVla1ZW+0CaRtFnDY9ffW8qqii/nAfOyFuBgaHgKS92TsuBPNzz7O0/7vz4x8jZXEoR9tg2w==",
+      "version": "1.6.162",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-1.6.162.tgz",
+      "integrity": "sha512-JHc10olNs3Dt89Qur4K3V29cKdM8sG0dg6sVTbsZAm2pzw/3d9AAhLiV614w7dCElovFwAl93V1fF/mgG5I48Q==",
       "dev": true,
       "requires": {
-        "@corex/deepmerge": "^2.6.20",
+        "@corex/deepmerge": "^2.6.34",
         "matcher": "^4.0.0",
         "minimist": "^1.2.5"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@testing-library/react": "^12.0.0",
         "algoliasearch": "^4.10.4",
         "apollo-link-rest": "^0.8.0-beta.0",
-        "autoprefixer": "^10.3.1",
+        "autoprefixer": "^10.3.2",
         "babel-jest": "^27.0.6",
         "babel-loader": "^8.2.2",
         "dayjs": "^1.10.6",
@@ -9574,14 +9574,14 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
-      "integrity": "sha512-L8AmtKzdiRyYg7BUXJTzigmhbQRCXFKz6SA1Lqo0+AR2FBbQ4aTAPFSDlOutnFkjhiz8my4agGXog1xlMjPJ6A==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.2.tgz",
+      "integrity": "sha512-RHKq0YCvhxAn9987n0Gl6lkzLd39UKwCkUPMFE0cHhxU0SvcTjBxWG/CtkZ4/HvbqK9U5V8j03nAcGBlX3er/Q==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.16.6",
-        "caniuse-lite": "^1.0.30001243",
-        "colorette": "^1.2.2",
+        "browserslist": "^4.16.8",
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
         "fraction.js": "^4.1.1",
         "normalize-range": "^0.1.2",
         "postcss-value-parser": "^4.1.0"
@@ -10555,16 +10555,16 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.811",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "node-releases": "^1.1.75"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -13081,9 +13081,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.806",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
-      "integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA=="
+      "version": "1.3.814",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
+      "integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw=="
     },
     "node_modules/element-resize-detector": {
       "version": "1.2.3",
@@ -22844,9 +22844,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.74",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw=="
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
     },
     "node_modules/nodemailer": {
       "version": "6.6.3",
@@ -40789,14 +40789,14 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
-      "integrity": "sha512-L8AmtKzdiRyYg7BUXJTzigmhbQRCXFKz6SA1Lqo0+AR2FBbQ4aTAPFSDlOutnFkjhiz8my4agGXog1xlMjPJ6A==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.2.tgz",
+      "integrity": "sha512-RHKq0YCvhxAn9987n0Gl6lkzLd39UKwCkUPMFE0cHhxU0SvcTjBxWG/CtkZ4/HvbqK9U5V8j03nAcGBlX3er/Q==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.6",
-        "caniuse-lite": "^1.0.30001243",
-        "colorette": "^1.2.2",
+        "browserslist": "^4.16.8",
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
         "fraction.js": "^4.1.1",
         "normalize-range": "^0.1.2",
         "postcss-value-parser": "^4.1.0"
@@ -41556,16 +41556,16 @@
       }
     },
     "browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.811",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "node-releases": "^1.1.75"
       }
     },
     "bser": {
@@ -43572,9 +43572,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.806",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz",
-      "integrity": "sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA=="
+      "version": "1.3.814",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
+      "integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw=="
     },
     "element-resize-detector": {
       "version": "1.2.3",
@@ -51112,9 +51112,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.74",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw=="
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
     },
     "nodemailer": {
       "version": "6.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "hamburger-react": "^2.4.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.0.6",
-        "markdownlint": "^0.23.1",
+        "markdownlint": "^0.24.0",
         "markdownlint-cli": "^0.28.1",
         "next-seo": "^4.26.0",
         "next-sitemap": "^1.6.157",
@@ -21345,9 +21345,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
-      "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.2.0.tgz",
+      "integrity": "sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
@@ -21388,12 +21388,12 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
-      "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.24.0.tgz",
+      "integrity": "sha512-OJIGsGFV/rC9irI5E1FMy6v9hdACSwaa+EN3224Y5KG8zj2EYzdHOw0pOJovIYmjNfEZ9BtxUY4P7uYHTSNnbQ==",
       "dev": true,
       "dependencies": {
-        "markdown-it": "12.0.4"
+        "markdown-it": "12.2.0"
       },
       "engines": {
         "node": ">=10"
@@ -21442,6 +21442,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/markdownlint-cli/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/markdownlint-cli/node_modules/ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -21461,6 +21470,34 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/markdown-it": {
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
+      "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/markdownlint": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
+      "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
+      "dev": true,
+      "dependencies": {
+        "markdown-it": "12.0.4"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdownlint-rule-helpers": {
@@ -49932,9 +49969,9 @@
       "dev": true
     },
     "markdown-it": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
-      "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.2.0.tgz",
+      "integrity": "sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1",
@@ -49965,12 +50002,12 @@
       "dev": true
     },
     "markdownlint": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
-      "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.24.0.tgz",
+      "integrity": "sha512-OJIGsGFV/rC9irI5E1FMy6v9hdACSwaa+EN3224Y5KG8zj2EYzdHOw0pOJovIYmjNfEZ9BtxUY4P7uYHTSNnbQ==",
       "dev": true,
       "requires": {
-        "markdown-it": "12.0.4"
+        "markdown-it": "12.2.0"
       }
     },
     "markdownlint-cli": {
@@ -50007,6 +50044,12 @@
           "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ==",
           "dev": true
         },
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+          "dev": true
+        },
         "ignore": {
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -50020,6 +50063,28 @@
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"
+          }
+        },
+        "markdown-it": {
+          "version": "12.0.4",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
+          "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1",
+            "entities": "~2.1.0",
+            "linkify-it": "^3.0.1",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        },
+        "markdownlint": {
+          "version": "0.23.1",
+          "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
+          "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
+          "dev": true,
+          "requires": {
+            "markdown-it": "12.0.4"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jest": "^24.4.0",
     "eslint-plugin-jsdoc": "^36.0.7",
-    "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-prettier": "^3.4.1",
     "formidable": "^1.2.2",
     "formik": "^2.2.9",
     "graphql": "^15.5.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@storybook/react": "^6.3.7",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
-    "algoliasearch": "^4.10.3",
+    "algoliasearch": "^4.10.4",
     "apollo-link-rest": "^0.8.0-beta.0",
     "autoprefixer": "^10.3.1",
     "babel-jest": "^27.0.6",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "hamburger-react": "^2.4.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.0.6",
-    "markdownlint": "^0.23.1",
+    "markdownlint": "^0.24.0",
     "markdownlint-cli": "^0.28.1",
     "next-seo": "^4.26.0",
     "next-sitemap": "^1.6.157",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@apollo/client": "^3.4.7",
+    "@apollo/client": "^3.4.8",
     "@arkweid/lefthook": "^0.7.6",
     "@babel/core": "^7.15.0",
     "@next/bundle-analyzer": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "markdownlint": "^0.24.0",
     "markdownlint-cli": "^0.28.1",
     "next-seo": "^4.26.0",
-    "next-sitemap": "^1.6.157",
+    "next-sitemap": "^1.6.162",
     "postcss": "^8.3.6",
     "postcss-flexbugs-fixes": "5.0.2",
     "postcss-preset-env": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@testing-library/react": "^12.0.0",
     "algoliasearch": "^4.10.4",
     "apollo-link-rest": "^0.8.0-beta.0",
-    "autoprefixer": "^10.3.1",
+    "autoprefixer": "^10.3.2",
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.2.2",
     "dayjs": "^1.10.6",


### PR DESCRIPTION
Closes #599
Closes #600
Closes #601

Related PR https://github.com/WebDevStudios/wds-headless-wordpress/pull/53

https://nextjs-wordpress-starter-2m4ykwxij-webdevstudios.vercel.app/

### Description

This PR updates the following Node dependencies:

```bash
 @apollo/client            ^3.4.7  →    ^3.4.8     
 algoliasearch            ^4.10.3  →   ^4.10.4     
 autoprefixer             ^10.3.1  →   ^10.3.2     
 eslint-plugin-prettier    ^3.4.0  →    ^3.4.1     
 markdownlint             ^0.23.1  →   ^0.24.0     
 next-sitemap            ^1.6.157  →  ^1.6.162  
```

### Screenshot

Front-end:

![screenshot](https://dl.dropbox.com/s/04o5jc1t59i923x/Screen%20Shot%202021-08-23%20at%2010.06.08%20AM.png?dl=0)

### Verification

How will a stakeholder test this?

1. `gh pr checkout 603`
2. `npm ci`
3. `npm run build && npm start`
4. Verify the front-end loads and works as expected
