### PR TITLE
Hotfix/602 separator full width

### DIFF
--- a/components/atoms/Separator/Separator.js
+++ b/components/atoms/Separator/Separator.js
@@ -15,13 +15,14 @@ import styles from './Separator.module.css'
  */
 export default function Separator({anchor, className, fullWidth}) {
   return (
-    <>
-      {fullWidth ? (
-        <hr id={anchor} className={cn(styles.separator, className)} />
-      ) : (
-        <hr id={anchor} className={cn(styles.separator, className)} />
+    <hr
+      id={anchor}
+      className={cn(
+        styles.separator,
+        !fullWidth && styles.containerWidth,
+        className
       )}
-    </>
+    />
   )
 }
 

--- a/components/atoms/Separator/Separator.module.css
+++ b/components/atoms/Separator/Separator.module.css
@@ -1,3 +1,7 @@
 .separator {
   @apply w-full border-b my-8;
+
+  &.containerWidth {
+    @apply container;
+  }
 }


### PR DESCRIPTION
Closes #602 

### Description

There was a check for full width but both renders were the same.
* I moved the check inside the `cn()` function to simplify
* Also made sure the separator is container width unless `fullWidth` is true

### Screenshot

See storybook.

Container width:
![ 2021-08-23 at 13 53 41 ](https://user-images.githubusercontent.com/12365909/130493977-a178f927-3a19-4c9a-a5c1-fefe51765e07.png)

Full width:
![ 2021-08-23 at 13 53 50 ](https://user-images.githubusercontent.com/12365909/130494005-4e89e6f3-150b-44d1-b364-815cd7b28be1.png)

### Verification

How will a stakeholder test this?

1. Run storybook or the frontend
2. Navigate to the separator component in storybook or on the front end
3. Observe that separators without `fullWidth` set are container width
4. Observe that separators with `fullWidth` set stretch the full width of the screen (minus any padding or margins)
