### PR TITLE
Feature/add jest tests

### DIFF
--- a/components/atoms/Breadcrumbs/Breadcrumbs.js
+++ b/components/atoms/Breadcrumbs/Breadcrumbs.js
@@ -1,7 +1,7 @@
+import cn from 'classnames'
 import Link from 'next/link'
 import PropTypes from 'prop-types'
 import styles from './Breadcrumbs.module.css'
-import cn from 'classnames'
 
 /**
  * Render the Breadcrumbs component.

--- a/components/atoms/Button/Button.js
+++ b/components/atoms/Button/Button.js
@@ -14,7 +14,7 @@ import styles from './Button.module.css'
  * @param  {string}  props.text     Button text or aria-label.
  * @return {Element}                The inside of the Button component.
  */
-function ButtonInner({icon, iconOnly, text}) {
+export function ButtonInner({icon, iconOnly, text}) {
   return (
     <>
       {!iconOnly && <span className={styles.text}>{text}</span>}

--- a/components/atoms/Button/index.js
+++ b/components/atoms/Button/index.js
@@ -1,1 +1,1 @@
-export {default} from './Button'
+export {ButtonInner, default} from './Button'

--- a/components/atoms/Icon/Icon.js
+++ b/components/atoms/Icon/Icon.js
@@ -6,9 +6,9 @@ import {icons} from './icons'
  * Convert icon size to px taking rem into account.
  *
  * @param  {string} size The icon size.
- * @return {string}      The size in px.
+ * @return {number}      The size in px.
  */
-function sizeToPx(size) {
+export function sizeToPx(size) {
   const sizeToRem = {
     sm: '1',
     md: '1.25',

--- a/components/atoms/Icon/index.js
+++ b/components/atoms/Icon/index.js
@@ -1,1 +1,1 @@
-export {default} from './Icon'
+export {default, sizeToPx} from './Icon'

--- a/components/atoms/Table/Table.js
+++ b/components/atoms/Table/Table.js
@@ -9,9 +9,9 @@ import styles from './Table.module.css'
  * @author WebDevStudios
  * @param  {object}  props           The component properties.
  * @param  {string}  props.id        Optional anchor/id.
- * @param  {string}  props.head      The optional table head array.
- * @param  {string}  props.body      The table body array.
- * @param  {string}  props.foot      The optional table foorter array.
+ * @param  {Array}   props.head      The optional table head array.
+ * @param  {Array}   props.body      The table body array.
+ * @param  {Array}   props.foot      The optional table foorter array.
  * @param  {string}  props.caption   Optional table caption.
  * @param  {string}  props.className Optional classnames.
  * @return {Element}                 The Table component.

--- a/tests/jest/components/atoms/Breadcrumbs.test.js
+++ b/tests/jest/components/atoms/Breadcrumbs.test.js
@@ -1,0 +1,50 @@
+import Breadcrumbs from '@/components/atoms/Breadcrumbs'
+import {render} from '@testing-library/react'
+
+test('render Breadcrumbs', () => {
+  const props = {
+    breadcrumbs: [
+      {
+        text: 'Home',
+        url: 'http://localhost:3000/'
+      },
+      {
+        text: 'Blog',
+        url: 'http://localhost:3000/blog'
+      },
+      {
+        text: 'Lorem Ipsum',
+        url: 'http://localhost:3000/blog/lorem-ipsum'
+      }
+    ]
+  }
+
+  const {container} = render(<Breadcrumbs {...props} />)
+
+  expect(container.firstElementChild).toHaveClass('breadcrumbs')
+
+  const lists = container.firstElementChild.querySelectorAll('li')
+
+  expect(lists).toHaveLength(3)
+
+  // Breadcrumbs should be in order
+  // Home -> Blog -> Lorem Ipsum
+
+  expect(lists[0].querySelector('a')).toHaveAttribute(
+    'href',
+    'http://localhost:3000/'
+  )
+  expect(lists[0]).toHaveTextContent('Home')
+
+  expect(lists[1].querySelector('a')).toHaveAttribute(
+    'href',
+    'http://localhost:3000/blog'
+  )
+  expect(lists[1]).toHaveTextContent('Blog')
+
+  expect(lists[2].querySelector('a')).toHaveAttribute(
+    'href',
+    'http://localhost:3000/blog/lorem-ipsum'
+  )
+  expect(lists[2]).toHaveTextContent('Lorem Ipsum')
+})

--- a/tests/jest/components/atoms/Button.test.js
+++ b/tests/jest/components/atoms/Button.test.js
@@ -1,0 +1,129 @@
+import Button, {ButtonInner} from '@/components/atoms/Button'
+import {render} from '@testing-library/react'
+
+test('render ButtonInner with text prop', () => {
+  const props = {
+    text: 'Go Back'
+  }
+
+  const {container} = render(<ButtonInner {...props} />)
+
+  expect(container.querySelector('svg')).toBeNull()
+  expect(container.firstElementChild).toHaveTextContent('Go Back')
+})
+
+test('render ButtonInner with iconOnly prop', () => {
+  const props = {
+    iconOnly: true,
+    icon: 'arrowLeft',
+    text: 'Left'
+  }
+
+  const {container} = render(<ButtonInner {...props} />)
+
+  expect(container.querySelector('svg')).not.toBeNull()
+  expect(container.firstElementChild).not.toHaveTextContent()
+})
+
+test('render ButtonInner with icon, and text props', () => {
+  const props = {
+    iconOnly: false,
+    icon: 'arrowLeft',
+    text: 'Go to the left'
+  }
+
+  const {container} = render(<ButtonInner {...props} />)
+
+  expect(container.querySelector('svg')).not.toBeNull()
+  expect(container.firstElementChild).toHaveTextContent('Go to the left')
+})
+
+test('render Button with text, and url props', () => {
+  const props = {
+    text: 'Sample button',
+    url: '/blog'
+  }
+
+  const {container} = render(<Button {...props} />)
+
+  expect(container.firstElementChild).toHaveAttribute('href', '/blog')
+  expect(container.firstElementChild).toHaveTextContent('Sample button')
+})
+
+test('render Button with className, fluid, icon, iconLeft, size, text and url props', () => {
+  const props = {
+    className: 'btn-test',
+    fluid: true,
+    icon: 'arrowLeft',
+    iconLeft: true,
+    size: 'lg',
+    text: 'Button with arrow left',
+    url: 'https://webdevstudios.com',
+    urlExternal: true
+  }
+
+  const {container} = render(<Button {...props} />)
+
+  expect(container.firstElementChild).toHaveClass('btn-test fluid lg')
+  expect(container.firstElementChild).toHaveAttribute(
+    'href',
+    'https://webdevstudios.com'
+  )
+  expect(container).toHaveTextContent('Button with arrow left')
+  expect(container.querySelector('svg')).not.toBeNull()
+})
+
+test('render Button with attributes, disabled, icon, iconOnly, size, styleOutline, text and url props', () => {
+  const props = {
+    attributes: {
+      'aria-expanded': true,
+      'aria-hidden': false
+    },
+    disabled: true,
+    icon: 'arrowLeft',
+    iconOnly: true,
+    size: 'sm',
+    styleOutline: true,
+    text: 'Outlined button',
+    url: '/blog/lorem-ipsum'
+  }
+
+  const {container} = render(<Button {...props} />)
+
+  expect(container.firstElementChild).toHaveAttribute(
+    'href',
+    '/blog/lorem-ipsum'
+  )
+  expect(container.firstElementChild).toHaveAttribute('aria-expanded', 'true')
+  expect(container.firstElementChild).toHaveAttribute('aria-hidden', 'false')
+  expect(container.firstElementChild).toHaveClass(
+    'iconOnly disabled sm styleOutline'
+  )
+  expect(container).not.toHaveTextContent()
+})
+
+test('render Button with text props', () => {
+  const props = {
+    text: 'Simple button'
+  }
+
+  const {container} = render(<Button {...props} />)
+
+  const button = container.querySelector('button')
+
+  expect(button).not.toBeNull()
+  expect(button).toHaveTextContent('Simple button')
+})
+
+test('render Button with tag, and text props', () => {
+  const props = {
+    tag: 'div',
+    text: 'Div button'
+  }
+
+  const {container} = render(<Button {...props} />)
+
+  expect(container.querySelector('button')).toBeNull()
+  expect(container.querySelector('div')).not.toBeNull()
+  expect(container.querySelector('div')).toHaveTextContent('Div button')
+})

--- a/tests/jest/components/atoms/Code.test.js
+++ b/tests/jest/components/atoms/Code.test.js
@@ -1,0 +1,26 @@
+import Code from '@/components/atoms/Code'
+import {render} from '@testing-library/react'
+
+test('render Code with id, className, content, and style props', () => {
+  const props = {
+    id: 'test-code-id',
+    className: 'test-class-code',
+    content: '<p>this is a code block!</p>',
+    style: {
+      backgroundColor: 'blue'
+    }
+  }
+
+  const {container} = render(<Code {...props} />)
+
+  const parentDiv = container.querySelector('#test-code-id')
+
+  expect(parentDiv).not.toBeNull()
+  expect(parentDiv).toHaveStyle({
+    backgroundColor: 'blue'
+  })
+
+  const codeDiv = container.querySelector('code')
+  expect(codeDiv).toHaveClass('language-test-class-code')
+  expect(codeDiv).toHaveTextContent('<p>this is a code block!</p>')
+})

--- a/tests/jest/components/atoms/Container.test.js
+++ b/tests/jest/components/atoms/Container.test.js
@@ -1,0 +1,56 @@
+import Container from '@/components/atoms/Container'
+import {render} from '@testing-library/react'
+
+test('render Container with children and false paddingTop prop', () => {
+  const props = {
+    paddingTop: false,
+    paddingBtm: true
+  }
+  const {container} = render(
+    <Container {...props}>
+      <article>
+        <p>Lorem ipsum.</p>
+      </article>
+    </Container>
+  )
+
+  expect(container.firstElementChild).not.toHaveClass('paddingTop')
+  expect(container.firstElementChild).toHaveClass('paddingBtm')
+  expect(container.firstElementChild.innerHTML).toBe(
+    '<article><p>Lorem ipsum.</p></article>'
+  )
+})
+
+test('render Container with children and false padding props', () => {
+  const props = {
+    paddingTop: false,
+    paddingBtm: false
+  }
+  const {container} = render(
+    <Container {...props}>
+      <h1>Lorem ipsum.</h1>
+    </Container>
+  )
+
+  expect(container.firstElementChild).not.toHaveClass('paddingTop')
+  expect(container.firstElementChild).not.toHaveClass('paddingBtm')
+  expect(container.firstElementChild.innerHTML).toBe('<h1>Lorem ipsum.</h1>')
+})
+
+test('render Container with children and padding props', () => {
+  const props = {
+    paddingTop: true,
+    paddingBtm: true
+  }
+  const {container} = render(
+    <Container {...props}>
+      <img src="http://localhost/sample.png" alt="Sample img" />
+    </Container>
+  )
+
+  expect(container.firstElementChild).toHaveClass('paddingTop')
+  expect(container.firstElementChild).toHaveClass('paddingBtm')
+  expect(container.firstElementChild.innerHTML).toBe(
+    '<img src="http://localhost/sample.png" alt="Sample img">'
+  )
+})

--- a/tests/jest/components/atoms/Heading.test.js
+++ b/tests/jest/components/atoms/Heading.test.js
@@ -1,0 +1,69 @@
+import Heading from '@/components/atoms/Heading'
+import {render} from '@testing-library/react'
+
+test('render Heading with string children prop', () => {
+  const props = {
+    children: 'Heading'
+  }
+
+  const {container} = render(<Heading {...props} />)
+
+  const H1Title = container.querySelector('h1')
+
+  expect(H1Title).not.toBeNull()
+  expect(H1Title).toHaveTextContent('Heading')
+})
+
+test('render Heading with string children, id, and className prop', () => {
+  const props = {
+    children: 'Title',
+    className: 'title-cls',
+    id: 'title-id'
+  }
+
+  const {container} = render(<Heading {...props} />)
+
+  const H1Title = container.querySelector('h1')
+
+  expect(H1Title).not.toBeNull()
+  expect(H1Title).toHaveAttribute('id', 'title-id')
+  expect(H1Title).toHaveClass('title-cls')
+  expect(H1Title).toHaveTextContent('Title')
+})
+
+test('render Heading with string children, style, and tag prop', () => {
+  const props = {
+    children: 'H6 Title',
+    style: {
+      backgroundColor: 'blue'
+    },
+    tag: 'h6'
+  }
+
+  const {container} = render(<Heading {...props} />)
+
+  const H6Title = container.querySelector('h6')
+
+  expect(H6Title).not.toBeNull()
+  expect(H6Title).toHaveStyle({
+    backgroundColor: 'blue'
+  })
+  expect(H6Title).toHaveTextContent('H6 Title')
+})
+
+test('render Heading with children and tag prop', () => {
+  const props = {
+    tag: 'h2'
+  }
+
+  const {container} = render(
+    <Heading {...props}>
+      <strong>Secondary Heading</strong>
+    </Heading>
+  )
+
+  const H2Title = container.querySelector('h2')
+
+  expect(H2Title).not.toBeNull()
+  expect(H2Title.innerHTML).toBe('<strong>Secondary Heading</strong>')
+})

--- a/tests/jest/components/atoms/Icon.test.js
+++ b/tests/jest/components/atoms/Icon.test.js
@@ -1,0 +1,85 @@
+import Icon, {sizeToPx} from '@/components/atoms/Icon'
+import {icons} from '@/components/atoms/Icon/icons'
+import {render} from '@testing-library/react'
+
+test('sizeToPx', () => {
+  expect(sizeToPx('sm')).toBe(16)
+  expect(sizeToPx('md')).toBe(20)
+  expect(sizeToPx('lg')).toBe(24)
+})
+
+test('render Icon with ariaHidden, className, and icon props', () => {
+  const props = {
+    ariaHidden: false,
+    className: 'icon-cls-test',
+    icon: 'award',
+    size: 'sm'
+  }
+
+  const {container} = render(<Icon {...props} />)
+
+  const expectedSize = sizeToPx('sm').toString()
+
+  const icon = container.querySelector('svg')
+
+  expect(icon).toHaveAttribute('aria-hidden', 'false')
+  expect(icon).toHaveClass('icon-cls-test')
+  expect(icon).toHaveAttribute('height', expectedSize)
+  expect(icon).toHaveAttribute('width', expectedSize)
+})
+
+test('render Icon with icon, size and title props', () => {
+  const props = {
+    icon: 'arrowRight',
+    size: 'md',
+    title: 'Right Arrow'
+  }
+
+  const expectedSize = sizeToPx('md').toString()
+
+  const {container} = render(<Icon {...props} />)
+
+  const icon = container.querySelector('svg')
+
+  expect(icon).toHaveAttribute('height', expectedSize)
+  expect(icon).toHaveAttribute('width', expectedSize)
+
+  expect(container.querySelector('title')).toHaveTextContent('Right Arrow')
+})
+
+test('render Icon with icon, size, and style-line props', () => {
+  const props = {
+    icon: 'volumeUp',
+    size: 'lg',
+    style: 'line'
+  }
+
+  const expectedSize = sizeToPx('lg').toString()
+
+  const {container} = render(<Icon {...props} />)
+
+  const icon = container.querySelector('svg')
+
+  expect(icon).toHaveAttribute('height', expectedSize)
+  expect(icon).toHaveAttribute('width', expectedSize)
+  expect(icon.querySelector('path')).toHaveAttribute(
+    'd',
+    icons['volumeUp']['line']
+  )
+})
+
+test('render Icon with icon, and style-fill props', () => {
+  const props = {
+    icon: 'unlock',
+    style: 'fill'
+  }
+
+  const {container} = render(<Icon {...props} />)
+
+  const icon = container.querySelector('svg')
+
+  expect(icon.querySelector('path')).toHaveAttribute(
+    'd',
+    icons['unlock']['unlock']
+  )
+})

--- a/tests/jest/components/atoms/Logo.test.js
+++ b/tests/jest/components/atoms/Logo.test.js
@@ -1,0 +1,28 @@
+import Logo from '@/components/atoms/Logo'
+import {render} from '@testing-library/react'
+
+test('render Logo with className, and type-dark props', () => {
+  const props = {
+    className: 'logo-ctm-cls',
+    type: 'dark'
+  }
+
+  const {container} = render(<Logo {...props} />)
+
+  const logo = container.querySelector('svg')
+
+  expect(logo).toHaveClass('logo-ctm-cls')
+  expect(logo).toHaveAttribute('fill', '#414141')
+})
+
+test('render Logo with type-light prop', () => {
+  const props = {
+    type: 'light'
+  }
+
+  const {container} = render(<Logo {...props} />)
+
+  const logo = container.querySelector('svg')
+
+  expect(logo).toHaveAttribute('fill', '#f9fbfd')
+})

--- a/tests/jest/components/atoms/PullQuote.test.js
+++ b/tests/jest/components/atoms/PullQuote.test.js
@@ -1,0 +1,43 @@
+import PullQuote from '@/components/atoms/PullQuote'
+import {render} from '@testing-library/react'
+
+test('render PullQuote with className, id, style and value props', () => {
+  const props = {
+    className: 'ctm-cls-pq',
+    id: 'ctm-id-pq',
+    style: {
+      backgroundColor: 'green'
+    },
+    value:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sed molestie lorem. '
+  }
+
+  const {container} = render(<PullQuote {...props} />)
+
+  expect(container.firstElementChild).toHaveClass('ctm-cls-pq')
+  expect(container.firstElementChild).not.toHaveClass('styleSolid')
+  expect(container.firstElementChild).toHaveAttribute('id', 'ctm-id-pq')
+  expect(container.firstElementChild).toHaveStyle({
+    backgroundColor: 'green'
+  })
+  expect(container).toHaveTextContent(
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sed molestie lorem.'
+  )
+})
+
+test('render PullQuote with citation, styleSolid, and value props', () => {
+  const props = {
+    citation: 'Lorem ipsum',
+    styleSolid: true,
+    value:
+      'Nullam diam massa, vulputate eu augue pellentesque, efficitur pellentesque ante.'
+  }
+
+  const {container} = render(<PullQuote {...props} />)
+
+  expect(container.firstElementChild).toHaveClass('styleSolid')
+  expect(container.querySelector('blockquote')).toHaveTextContent(
+    'Nullam diam massa, vulputate eu augue pellentesque, efficitur pellentesque ante.'
+  )
+  expect(container.querySelector('.cite')).toHaveTextContent('Lorem ipsum')
+})

--- a/tests/jest/components/atoms/Quote.test.js
+++ b/tests/jest/components/atoms/Quote.test.js
@@ -1,0 +1,33 @@
+import Quote from '@/components/atoms/Quote'
+import {render} from '@testing-library/react'
+
+test('render Quote with className, id, style and value props', () => {
+  const props = {
+    className: 'ctm-cls-q',
+    id: 'ctm-id-q',
+    value:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sed molestie lorem.'
+  }
+
+  const {container} = render(<Quote {...props} />)
+
+  expect(container.firstElementChild).toHaveClass('ctm-cls-q')
+  expect(container.firstElementChild).toHaveAttribute('id', 'ctm-id-q')
+  expect(container).toHaveTextContent(
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sed molestie lorem.'
+  )
+})
+
+test('render Quote with citation and value props', () => {
+  const props = {
+    citation: 'Lorem',
+    value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+  }
+
+  const {container} = render(<Quote {...props} />)
+
+  expect(container).toHaveTextContent(
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+  )
+  expect(container.querySelector('.cite')).toHaveTextContent('Lorem')
+})

--- a/tests/jest/components/atoms/RichText.test.js
+++ b/tests/jest/components/atoms/RichText.test.js
@@ -1,0 +1,43 @@
+import RichText from '@/components/atoms/RichText'
+import {render} from '@testing-library/react'
+
+test('render RichText with children, className, dropCap and style props', () => {
+  const props = {
+    className: 'custom-rt-cls',
+    dropCap: true,
+    style: {
+      backgroundColor: 'red'
+    }
+  }
+
+  const {container} = render(
+    <RichText {...props}>This is a rich text example.</RichText>
+  )
+
+  expect(container.firstElementChild).toHaveClass('dropcap custom-rt-cls')
+  expect(container.firstElementChild).toHaveStyle({
+    backgroundColor: 'red'
+  })
+  expect(container).toHaveTextContent('This is a rich text example.')
+})
+
+test('render RichText with attributes, children, id and tag props', () => {
+  const props = {
+    attributes: {
+      'data-att': true
+    },
+    id: 'rt-ctm-id',
+    tag: 'span'
+  }
+
+  const {container} = render(
+    <RichText {...props}>This is a span example.</RichText>
+  )
+
+  const richTextSpan = container.querySelector('span')
+
+  expect(richTextSpan).not.toHaveClass('dropcap')
+  expect(richTextSpan).toHaveAttribute('id', 'rt-ctm-id')
+  expect(richTextSpan).toHaveAttribute('data-att', 'true')
+  expect(richTextSpan).toHaveTextContent('This is a span example.')
+})

--- a/tests/jest/components/atoms/Separator.test.js
+++ b/tests/jest/components/atoms/Separator.test.js
@@ -7,9 +7,7 @@ test('render Separator with anchor, and className props', () => {
     className: 'test-cls'
   }
 
-  const {container, debug} = render(<Separator {...props} />)
-
-  debug()
+  const {container} = render(<Separator {...props} />)
 
   expect(container.firstElementChild).toHaveClass('test-cls')
   expect(container.firstElementChild).toHaveAttribute('id', 'test-anchor')

--- a/tests/jest/components/atoms/Separator.test.js
+++ b/tests/jest/components/atoms/Separator.test.js
@@ -1,0 +1,16 @@
+import Separator from '@/components/atoms/Separator'
+import {render} from '@testing-library/react'
+
+test('render Separator with anchor, and className props', () => {
+  const props = {
+    anchor: 'test-anchor',
+    className: 'test-cls'
+  }
+
+  const {container, debug} = render(<Separator {...props} />)
+
+  debug()
+
+  expect(container.firstElementChild).toHaveClass('test-cls')
+  expect(container.firstElementChild).toHaveAttribute('id', 'test-anchor')
+})

--- a/tests/jest/components/atoms/Spacer.test.js
+++ b/tests/jest/components/atoms/Spacer.test.js
@@ -1,0 +1,16 @@
+import Spacer from '@/components/atoms/Spacer'
+import {render} from '@testing-library/react'
+
+test('render Spacer with height prop', () => {
+  const props = {
+    height: 12
+  }
+
+  const {container} = render(<Spacer {...props} />)
+
+  const computedHeight = 12 / 16
+
+  expect(container.firstElementChild).toHaveStyle({
+    height: `${computedHeight}rem`
+  })
+})

--- a/tests/jest/components/atoms/Table.test.js
+++ b/tests/jest/components/atoms/Table.test.js
@@ -1,0 +1,170 @@
+import Table from '@/components/atoms/Table'
+import {render} from '@testing-library/react'
+
+test('render Table with body, head, and id props', () => {
+  const props = {
+    body: [
+      {
+        cells: [
+          {
+            align: '',
+            content: 'Column 1 - Row 1',
+            scope: '',
+            tag: 'td'
+          },
+          {
+            align: 'center',
+            content: 'Column 2 - Row 1',
+            scope: '',
+            tag: 'td'
+          }
+        ]
+      },
+      {
+        cells: [
+          {
+            align: '',
+            content: 'Column 1 - Row 2',
+            scope: '',
+            tag: 'td'
+          },
+          {
+            align: 'right',
+            content: 'Column 2 - Row 2',
+            scope: '',
+            tag: 'td'
+          }
+        ]
+      }
+    ],
+    head: [
+      {
+        cells: [
+          {
+            align: '',
+            content: 'Head 1',
+            scope: ''
+          },
+          {
+            align: 'center',
+            content: 'Head 2',
+            scope: ''
+          }
+        ]
+      }
+    ],
+    id: 'test-tbl-id'
+  }
+
+  const {container} = render(<Table {...props} />)
+
+  expect(container.firstElementChild).toHaveAttribute('id', 'test-tbl-id')
+
+  const head = container.querySelector('thead').querySelectorAll('th')
+
+  expect(head).toHaveLength(2)
+  expect(head[0]).toHaveTextContent('Head 1')
+
+  expect(head[1]).toHaveClass('text-center')
+  expect(head[1]).toHaveTextContent('Head 2')
+
+  const body = container.querySelector('tbody').querySelectorAll('tr')
+
+  expect(body).toHaveLength(2)
+
+  // Row 1
+  const row1 = body[0].querySelectorAll('td')
+  expect(row1).toHaveLength(2)
+
+  // Row 1 - Column 1
+  expect(row1[0]).toHaveClass('text-left')
+  expect(row1[0]).toHaveTextContent('Column 1 - Row 1')
+
+  // Row 1 - Column 2
+  expect(row1[1]).toHaveClass('text-center')
+  expect(row1[1]).toHaveTextContent('Column 2 - Row 1')
+
+  // Row 2
+  const row2 = body[1].querySelectorAll('td')
+  expect(row2).toHaveLength(2)
+
+  // Row 2 - Column 1
+  expect(row2[0]).toHaveClass('text-left')
+  expect(row2[0]).toHaveTextContent('Column 1 - Row 2')
+
+  // Row 2 - Column 2
+  expect(row2[1]).toHaveClass('text-right')
+  expect(row2[1]).toHaveTextContent('Column 2 - Row 2')
+})
+
+test('render Table with className, caption, and foot props', () => {
+  const props = {
+    body: [
+      {
+        cells: [
+          {
+            align: '',
+            content: 'Column 1 - Row 1',
+            scope: '',
+            tag: 'td'
+          },
+          {
+            align: 'center',
+            content: 'Column 2 - Row 1',
+            scope: '',
+            tag: 'td'
+          }
+        ]
+      }
+    ],
+    className: 'test-tbl-cls',
+    foot: [
+      {
+        cells: [
+          {
+            align: 'right',
+            content: 'Foot 1',
+            scope: ''
+          },
+          {
+            align: '',
+            content: 'Foot 2',
+            scope: ''
+          }
+        ]
+      }
+    ],
+    caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+  }
+
+  const {container} = render(<Table {...props} />)
+
+  expect(container.firstElementChild).toHaveClass('test-tbl-cls')
+
+  const row1 = container
+    .querySelector('tbody')
+    .querySelector('tr')
+    .querySelectorAll('td')
+
+  expect(row1[0]).toHaveTextContent('Column 1 - Row 1')
+  expect(row1[0]).toHaveClass('text-left')
+
+  expect(row1[1]).toHaveTextContent('Column 2 - Row 1')
+  expect(row1[1]).toHaveClass('text-center')
+
+  const foot = container
+    .querySelector('tfoot')
+    .querySelector('tr')
+    .querySelectorAll('td')
+
+  expect(foot[0]).toHaveTextContent('Foot 1')
+  expect(foot[0]).toHaveClass('text-right')
+
+  expect(foot[1]).toHaveTextContent('Foot 2')
+  expect(foot[1]).toHaveClass('text-left')
+
+  // Caption
+  expect(container.querySelector('.caption')).toHaveTextContent(
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+  )
+})

--- a/tests/jest/components/molecules/Alert.test.js
+++ b/tests/jest/components/molecules/Alert.test.js
@@ -1,0 +1,52 @@
+import Alert from '@/components/molecules/Alert'
+import {render} from '@testing-library/react'
+
+test('render Alert with body, className, icon, and type=default props', () => {
+  const props = {
+    body: 'Default Alert',
+    className: 'custom-alert-cls',
+    icon: 'award',
+    type: 'default'
+  }
+
+  const {container} = render(<Alert {...props} />)
+
+  expect(container.firstElementChild).toHaveClass('custom-alert-cls')
+  expect(container.firstElementChild).not.toHaveClass('success')
+  expect(container.querySelector('svg')).not.toBeNull()
+  expect(container.firstElementChild.querySelector('.body')).toHaveTextContent(
+    'Default Alert'
+  )
+})
+
+test('render Alert with body, icon, and type=success props', () => {
+  const props = {
+    body: 'Success Alert',
+    icon: 'award',
+    type: 'success'
+  }
+
+  const {container} = render(<Alert {...props} />)
+
+  expect(container.firstElementChild).toHaveClass('success')
+  expect(container.querySelector('svg')).not.toBeNull()
+  expect(container.firstElementChild.querySelector('.body')).toHaveTextContent(
+    'Success Alert'
+  )
+})
+
+test('render Alert with body, icon, and type=error props', () => {
+  const props = {
+    body: 'Error Alert',
+    icon: 'award',
+    type: 'error'
+  }
+
+  const {container} = render(<Alert {...props} />)
+
+  expect(container.firstElementChild).toHaveClass('error')
+  expect(container.querySelector('svg')).not.toBeNull()
+  expect(container.firstElementChild.querySelector('.body')).toHaveTextContent(
+    'Error Alert'
+  )
+})

--- a/tests/jest/components/molecules/ButtonGroup.test.js
+++ b/tests/jest/components/molecules/ButtonGroup.test.js
@@ -1,0 +1,38 @@
+import ButtonGroup from '@/components/molecules/ButtonGroup'
+import {render} from '@testing-library/react'
+
+test('render ButtonGroup with id, orientation=horizontal, contentJustification=left, and children props', () => {
+  const props = {
+    id: 'test-id-btngrp',
+    orientation: 'horizontal',
+    contentJustification: 'left'
+  }
+
+  const {container} = render(
+    <ButtonGroup {...props}>
+      <button>Test btn</button>
+    </ButtonGroup>
+  )
+
+  expect(container.firstElementChild).toHaveClass('horizontal left')
+  expect(container.firstElementChild).toHaveAttribute('id', 'test-id-btngrp')
+  expect(container.firstElementChild.innerHTML).toBe(
+    '<button>Test btn</button>'
+  )
+})
+
+test('render ButtonGroup with id, orientation=vertical, contentJustification=right, and children props', () => {
+  const props = {
+    orientation: 'vertical',
+    contentJustification: 'right'
+  }
+
+  const {container} = render(
+    <ButtonGroup {...props}>
+      <div>Lorem ipsum</div>
+    </ButtonGroup>
+  )
+
+  expect(container.firstElementChild).toHaveClass('vertical right')
+  expect(container.firstElementChild.innerHTML).toBe('<div>Lorem ipsum</div>')
+})

--- a/tests/jest/components/molecules/Card.test.js
+++ b/tests/jest/components/molecules/Card.test.js
@@ -1,0 +1,94 @@
+import Card from '@/components/molecules/Card'
+import {render} from '@testing-library/react'
+
+test('render Card with body, className, meta, and title props', () => {
+  const props = {
+    body: '<p>Donec eget nulla ultricies, aliquam ex nec, commodo tellus.</p>',
+    className: 'test-crd-cls',
+    meta: 'Test Meta',
+    title: 'Lorem ipsum'
+  }
+
+  const {container} = render(<Card {...props} />)
+
+  const card = container.firstElementChild
+
+  expect(card).toHaveClass('test-crd-cls')
+  expect(card.querySelector('.meta')).toHaveTextContent('Test Meta')
+  expect(card.querySelector('h1')).toHaveTextContent('Lorem ipsum')
+  expect(card.querySelector('.body')).toHaveTextContent(
+    'Donec eget nulla ultricies, aliquam ex nec, commodo tellus.'
+  )
+})
+
+test('render Card with body, timestamp, title, and url props', () => {
+  const props = {
+    body: '<p>Nullam fringilla, metus a convallis euismod, erat mauris luctus quam, ut fringilla ipsum mauris at sapien.</p>',
+    timestamp: 'May 29, 2021',
+    title: 'Lorem ipsum',
+    url: '/blog'
+  }
+
+  const {container} = render(<Card {...props} />)
+
+  const card = container.firstElementChild
+
+  const title = card.querySelector('h1')
+
+  expect(title).toHaveTextContent('Lorem ipsum')
+  expect(title.parentElement).toHaveAttribute('href', '/blog')
+
+  expect(card.querySelector('.body').innerHTML).toBe(
+    '<p>Nullam fringilla, metus a convallis euismod, erat mauris luctus quam, ut fringilla ipsum mauris at sapien.</p>'
+  )
+
+  const footer = card.querySelector('.footer')
+  expect(footer.querySelector('time')).toHaveTextContent('May 29, 2021')
+})
+
+test('render Card with body, buttonText, image, and url props', () => {
+  const props = {
+    body: 'Sed a mauris magna. Integer tempus congue ligula, sed pretium risus luctus sit amet.',
+    buttonText: 'Aliquam pretium',
+    image: {
+      altText: 'Card image',
+      height: '110',
+      sourceUrl:
+        'https://images.unsplash.com/photo-1610991149688-c1321006bcc1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1110&q=60',
+      width: '200'
+    },
+    url: 'https://webdevstudios.com'
+  }
+
+  const {container} = render(<Card {...props} />)
+
+  const card = container.firstElementChild
+
+  expect(card.querySelector('.image').querySelector('img')).toHaveAttribute(
+    'alt',
+    'Card image'
+  )
+  expect(card.querySelector('.image').querySelector('img')).toHaveAttribute(
+    'height',
+    '110'
+  )
+  expect(card.querySelector('.image').querySelector('img')).toHaveAttribute(
+    'width',
+    '200'
+  )
+  expect(card.querySelector('.image').querySelector('img')).toHaveAttribute(
+    'src',
+    'https://images.unsplash.com/photo-1610991149688-c1321006bcc1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1110&q=60'
+  )
+
+  expect(card.querySelector('.body')).toHaveTextContent(
+    'Sed a mauris magna. Integer tempus congue ligula, sed pretium risus luctus sit amet.'
+  )
+
+  const footer = card.querySelector('.footer')
+
+  const button = footer.querySelector('.button')
+
+  expect(button).toHaveAttribute('href', 'https://webdevstudios.com')
+  expect(button).toHaveTextContent('Aliquam pretium')
+})


### PR DESCRIPTION
Related ticket: #493 

### Description

This PR adds unit tests using Jest for the following components:
- Breadcrumbs
- Button
- Code
- Container
- Heading
- Icon
- Logo
- PullQuote
- Quote
- RichText
- Separator
- Spacer
- Table
- Alert
- ButtonGroup
- Card

### Verification

How will a stakeholder test this?

1. Pull the PR branch.
2. Run `npm run test:jest`
3. Confirm all tests passed.
