### PR TITLE
feature/fix-team-member-display

### DIFF
--- a/frontend/lib/wordpress/teams/queryTeamById.js
+++ b/frontend/lib/wordpress/teams/queryTeamById.js
@@ -14,10 +14,6 @@ const singleTeamFragment = gql`
     ${seoPostFields}
     ${authorPostFields}
     ${featuredImagePostFields}
-    teamMemberProfile {
-      location
-      title
-    }
   }
 `
 


### PR DESCRIPTION
Closes #

### Description

Removes `teamMemberProfile` from team member query fragment (corresponding ACF fields removed during plugin creation).

### Screenshot

If possible, add some screenshots of your feature.

### Verification

https://nextjs-wordpress-starter.vercel.app/team
- click through several team member pages to ensure they don't 404