### PR TITLE
fix/653-formatfocalpoint

### DIFF
--- a/frontend/functions/formatFocalPoint.js
+++ b/frontend/functions/formatFocalPoint.js
@@ -7,8 +7,10 @@
  */
 export default function formatFocalPoint(focalPoint) {
   const newFocalPoint = {}
-  const x = parseFloat(focalPoint?.x || '.5') ?? 0.5
-  const y = parseFloat(focalPoint?.y || '.5') ?? 0.5
+  let x = focalPoint?.x
+  let y = focalPoint?.y
+  x = parseFloat(x && !isNaN(x) ? x : '.5') ?? 0.5
+  y = parseFloat(y && !isNaN(y) ? y : '.5') ?? 0.5
 
   newFocalPoint.x = `${x * 100}%`
   newFocalPoint.y = `${y * 100}%`


### PR DESCRIPTION
Closes #653 

### Description

Adds extra check for NaN to avoid errors

### Screenshot

Before
![Screen Shot 2021-09-10 at 3 17 17 PM](https://user-images.githubusercontent.com/36422618/132918639-d0a2b54a-db69-4f82-b49a-47cf851dff83.png)

After
![Screen Shot 2021-09-10 at 3 17 22 PM](https://user-images.githubusercontent.com/36422618/132918648-924409f5-9e01-49d5-bc84-37e2682c6bd6.png)

### Verification

can't be tested without manually calling the function and passing erroneous input
