### PR TITLE
fix/651-alpha-extractRgbValues

### DIFF
--- a/frontend/functions/extractRgbValues.js
+++ b/frontend/functions/extractRgbValues.js
@@ -8,12 +8,11 @@
  */
 export default function extractRgbValues(rgbString) {
   const rgbValues = rgbString.match(
-    /rgba?\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)?(?:, ?(\d(?:\.\d?))\))?/
+    /rgba?\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)?/
   )
 
-  // Remove first element (original RGB string) and last element (undefined).
+  // Remove first element (original RGB string).
   rgbValues.shift()
-  rgbValues.pop()
 
   return rgbValues
 }


### PR DESCRIPTION
Closes #651

### Description

Skips Regex check for RGB string alpha value as unneeded.

### Screenshot

If possible, add some screenshots of your feature.

### Verification

(can only be tested by manually calling the function and passing an RGBA string)
