### PR TITLE
Replace WORDPRESS_PREVIEW_SECRET with PREVIEW_SECRET_TOKEN in wp-config.php references

### DIFF
--- a/docs/docs/backend/index.md
+++ b/docs/docs/backend/index.md
@@ -174,7 +174,7 @@ See the [WDS Headless Gravity Forms documentation](https://webdevstudios.github.
 
 ## Enable Previews
 
-To enable previews, you'll need both a `WORDPRESS_PREVIEW_SECRET` constant in `wp-config.php` and `WORDPRESS_PREVIEW_SECRET` ENV variable in the frontend `.env` file.
+To enable previews, you'll need both a `PREVIEW_SECRET_TOKEN` constant in `wp-config.php` and `WORDPRESS_PREVIEW_SECRET` ENV variable in the frontend `.env` file.
 
 **The token can be any random string, as long as they match in both locations!**
 
@@ -182,7 +182,7 @@ WordPress:
 
 ```php
 // wp-config.php
-define('WORDPRESS_PREVIEW_SECRET', 'ANY_RANDOM_STRING');
+define('PREVIEW_SECRET_TOKEN', 'ANY_RANDOM_STRING');
 ```
 
 Next.js:

--- a/docs/docs/frontend/env-variables.md
+++ b/docs/docs/frontend/env-variables.md
@@ -28,7 +28,7 @@ WORDPRESS_URL="https://nextjs.wpengine.com/"
 ```
 
 ```text
-# This needs to match the WORDPRESS_PREVIEW_SECRET constant in wp-config.php. It can be any random string of text.
+# This needs to match the PREVIEW_SECRET_TOKEN constant in wp-config.php. It can be any random string of text.
 WORDPRESS_PREVIEW_SECRET="ANY_RANDOM_STRING_OF_TEXT"
 ```
 


### PR DESCRIPTION
Closes #723

### Description

Replaces a few uses of `WORDPRESS_PREVIEW_SECRET` with `PREVIEW_SECRET_TOKEN`, in references to a PHP constant to define in wp-config.php. I believe this covers all of the mistaken references.

### Screenshot

Before:

![Screen Shot 2021-10-06 at 9 04 53 AM](https://user-images.githubusercontent.com/5407441/136240447-83ad1931-0f70-45d8-b25d-c992695ea465.png)

After:

![Screen Shot 2021-10-06 at 10 57 53 AM](https://user-images.githubusercontent.com/5407441/136240382-c5673c15-5ec8-4fa5-b02e-b53b37ae132d.png)


Before:

![Screen Shot 2021-10-06 at 11 02 10 AM](https://user-images.githubusercontent.com/5407441/136241378-f94a0231-f4c4-4438-9c75-fb2198b0cfa1.png)

After:

![Screen Shot 2021-10-06 at 11 03 02 AM](https://user-images.githubusercontent.com/5407441/136241417-7a0fda35-5777-44b0-877c-64472b70e804.png)


### Verification

How will a stakeholder test this?

1. Checkout this branch
2. Run `npm install` and `npm run dev:docs`
3. Visit the two pages that were changed and verify that it appears to be correct

...or...

1. Just have a look at the diff, since these are just markdown docs
