### PR TITLE
Bulk Dependabots 2021-11-15

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,10 +27,10 @@
         "react-dom": "^17.0.2",
         "react-instantsearch-dom": "^6.15.0",
         "react-is": "^17.0.2",
-        "react-syntax-highlighter": "^15.4.4",
+        "react-syntax-highlighter": "^15.4.5",
         "react-twitter-embed": "^3.0.3",
         "rimraf": "^3.0.2",
-        "sharp": "^0.29.2",
+        "sharp": "^0.29.3",
         "tailwindcss": "^2.2.19",
         "yup": "^0.32.11"
       },
@@ -66,8 +66,8 @@
         "prettier": "^2.4.1",
         "prop-types": "^15.7.2",
         "storybook-css-modules-preset": "^1.1.1",
-        "stylelint": "^14.0.1",
-        "stylelint-config-standard": "^23.0.0"
+        "stylelint": "^14.1.0",
+        "stylelint-config-standard": "^24.0.0"
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
@@ -12987,14 +12987,17 @@
       }
     },
     "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dependencies": {
-        "mimic-response": "^2.0.0"
+        "mimic-response": "^3.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dedent": {
@@ -22096,11 +22099,11 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -22856,19 +22859,28 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.3.0.tgz",
+      "integrity": "sha512-/+2sCVPXmj07GY/l0ggRr7+trqzX7F9d4QVfSArqIVYmRzc/LkXKr5FlRO6U8uZ/gVVclDDaBxBNITj1z1Z/Zw==",
       "dependencies": {
-        "semver": "^5.4.1"
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -26043,9 +26055,9 @@
       "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
     },
     "node_modules/prebuild-install": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.0.tgz",
+      "integrity": "sha512-IvSenf33K7JcgddNz2D5w521EgO+4aMMjFt73Uk9FRzQ7P+QZPKrp7qPsDydsSwjGt3T5xRNnM1bj1zMTD5fTA==",
       "dependencies": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -26053,11 +26065,11 @@
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
+        "node-abi": "^3.3.0",
         "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
+        "simple-get": "^4.0.0",
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       },
@@ -26065,7 +26077,7 @@
         "prebuild-install": "bin.js"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -27108,14 +27120,14 @@
       }
     },
     "node_modules/react-syntax-highlighter": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.4.tgz",
-      "integrity": "sha512-PsOFHNTzkb3OroXdoR897eKN5EZ6grht1iM+f1lJSq7/L0YVnkJaNVwC3wEUYPOAmeyl5xyer1DjL6MrumO6Zw==",
+      "version": "15.4.5",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.5.tgz",
+      "integrity": "sha512-RC90KQTxZ/b7+9iE6s9nmiFLFjWswUcfULi4GwVzdFVKVMQySkJWBuOmJFfjwjMVCo0IUUuJrWebNKyviKpwLQ==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "highlight.js": "^10.4.1",
         "lowlight": "^1.17.0",
-        "prismjs": "^1.22.0",
+        "prismjs": "^1.25.0",
         "refractor": "^3.2.0"
       },
       "peerDependencies": {
@@ -28503,17 +28515,17 @@
       "dev": true
     },
     "node_modules/sharp": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.2.tgz",
-      "integrity": "sha512-XWRdiYLIJ3tDUejRyG24KERnJzMfIoyiJBntd2S6/uj3NEeNgRFRLgiBlvPxMa8aml14dKKD98yHinSNKp1xzQ==",
+      "version": "0.29.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
+      "integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.0.1",
         "detect-libc": "^1.0.3",
         "node-addon-api": "^4.2.0",
-        "prebuild-install": "^6.1.4",
+        "prebuild-install": "^7.0.0",
         "semver": "^7.3.5",
-        "simple-get": "^3.1.0",
+        "simple-get": "^4.0.0",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
       },
@@ -28602,11 +28614,25 @@
       ]
     },
     "node_modules/simple-get": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
+      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
-        "decompress-response": "^4.2.0",
+        "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
@@ -29644,9 +29670,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.0.1.tgz",
-      "integrity": "sha512-ZcAkmFLVCultmwkQUjxKzxW/o5+CzNmDk6TPJj/d4Y7ipTGGrewIWmNm+InjdSr04PR5/yynsAJeYJY/wisdMg==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.1.0.tgz",
+      "integrity": "sha512-IedkssuNVA11+v++2PIV2OHOU5A3SfRcXVi56vZVSsMhGrgtwmmit69jeM+08/Tun5DTBe7BuH1Zp1mMLmtKLA==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^2.0.0",
@@ -29661,7 +29687,7 @@
         "globby": "^11.0.4",
         "globjoin": "^0.1.4",
         "html-tags": "^3.1.0",
-        "ignore": "^5.1.8",
+        "ignore": "^5.1.9",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
@@ -29684,7 +29710,7 @@
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.7.2",
+        "table": "^6.7.3",
         "v8-compile-cache": "^2.3.0",
         "write-file-atomic": "^3.0.3"
       },
@@ -29709,9 +29735,9 @@
       }
     },
     "node_modules/stylelint-config-standard": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-23.0.0.tgz",
-      "integrity": "sha512-8PDlk+nWuc1T66nVaODTdVodN0pjuE5TBlopi39Lt9EM36YJsRhqttMyUhnS78oc/59Q6n8iw2GJB4QcoFqtRg==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-24.0.0.tgz",
+      "integrity": "sha512-+RtU7fbNT+VlNbdXJvnjc3USNPZRiRVp/d2DxOF/vBDDTi0kH5RX2Ny6errdtZJH3boO+bmqIYEllEmok4jiuw==",
       "dev": true,
       "dependencies": {
         "stylelint-config-recommended": "^6.0.0"
@@ -42872,11 +42898,11 @@
       "dev": true
     },
     "decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "requires": {
-        "mimic-response": "^2.0.0"
+        "mimic-response": "^3.1.0"
       }
     },
     "dedent": {
@@ -49916,9 +49942,9 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
     },
     "min-document": {
       "version": "2.19.0",
@@ -50485,17 +50511,20 @@
       }
     },
     "node-abi": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.3.0.tgz",
+      "integrity": "sha512-/+2sCVPXmj07GY/l0ggRr7+trqzX7F9d4QVfSArqIVYmRzc/LkXKr5FlRO6U8uZ/gVVclDDaBxBNITj1z1Z/Zw==",
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "^7.3.5"
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -52952,9 +52981,9 @@
       }
     },
     "prebuild-install": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.0.tgz",
+      "integrity": "sha512-IvSenf33K7JcgddNz2D5w521EgO+4aMMjFt73Uk9FRzQ7P+QZPKrp7qPsDydsSwjGt3T5xRNnM1bj1zMTD5fTA==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -52962,11 +52991,11 @@
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
+        "node-abi": "^3.3.0",
         "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
+        "simple-get": "^4.0.0",
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       }
@@ -53795,14 +53824,14 @@
       }
     },
     "react-syntax-highlighter": {
-      "version": "15.4.4",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.4.tgz",
-      "integrity": "sha512-PsOFHNTzkb3OroXdoR897eKN5EZ6grht1iM+f1lJSq7/L0YVnkJaNVwC3wEUYPOAmeyl5xyer1DjL6MrumO6Zw==",
+      "version": "15.4.5",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.5.tgz",
+      "integrity": "sha512-RC90KQTxZ/b7+9iE6s9nmiFLFjWswUcfULi4GwVzdFVKVMQySkJWBuOmJFfjwjMVCo0IUUuJrWebNKyviKpwLQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "highlight.js": "^10.4.1",
         "lowlight": "^1.17.0",
-        "prismjs": "^1.22.0",
+        "prismjs": "^1.25.0",
         "refractor": "^3.2.0"
       }
     },
@@ -54907,16 +54936,16 @@
       "dev": true
     },
     "sharp": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.2.tgz",
-      "integrity": "sha512-XWRdiYLIJ3tDUejRyG24KERnJzMfIoyiJBntd2S6/uj3NEeNgRFRLgiBlvPxMa8aml14dKKD98yHinSNKp1xzQ==",
+      "version": "0.29.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
+      "integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
       "requires": {
         "color": "^4.0.1",
         "detect-libc": "^1.0.3",
         "node-addon-api": "^4.2.0",
-        "prebuild-install": "^6.1.4",
+        "prebuild-install": "^7.0.0",
         "semver": "^7.3.5",
-        "simple-get": "^3.1.0",
+        "simple-get": "^4.0.0",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
       },
@@ -54972,11 +55001,11 @@
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
     },
     "simple-get": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
+      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
       "requires": {
-        "decompress-response": "^4.2.0",
+        "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
@@ -55811,9 +55840,9 @@
       }
     },
     "stylelint": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.0.1.tgz",
-      "integrity": "sha512-ZcAkmFLVCultmwkQUjxKzxW/o5+CzNmDk6TPJj/d4Y7ipTGGrewIWmNm+InjdSr04PR5/yynsAJeYJY/wisdMg==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.1.0.tgz",
+      "integrity": "sha512-IedkssuNVA11+v++2PIV2OHOU5A3SfRcXVi56vZVSsMhGrgtwmmit69jeM+08/Tun5DTBe7BuH1Zp1mMLmtKLA==",
       "dev": true,
       "requires": {
         "balanced-match": "^2.0.0",
@@ -55828,7 +55857,7 @@
         "globby": "^11.0.4",
         "globjoin": "^0.1.4",
         "html-tags": "^3.1.0",
-        "ignore": "^5.1.8",
+        "ignore": "^5.1.9",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
@@ -55851,7 +55880,7 @@
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.7.2",
+        "table": "^6.7.3",
         "v8-compile-cache": "^2.3.0",
         "write-file-atomic": "^3.0.3"
       },
@@ -55896,9 +55925,9 @@
       "dev": true
     },
     "stylelint-config-standard": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-23.0.0.tgz",
-      "integrity": "sha512-8PDlk+nWuc1T66nVaODTdVodN0pjuE5TBlopi39Lt9EM36YJsRhqttMyUhnS78oc/59Q6n8iw2GJB4QcoFqtRg==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-24.0.0.tgz",
+      "integrity": "sha512-+RtU7fbNT+VlNbdXJvnjc3USNPZRiRVp/d2DxOF/vBDDTi0kH5RX2Ny6errdtZJH3boO+bmqIYEllEmok4jiuw==",
       "dev": true,
       "requires": {
         "stylelint-config-recommended": "^6.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,10 +53,10 @@
     "react-dom": "^17.0.2",
     "react-instantsearch-dom": "^6.15.0",
     "react-is": "^17.0.2",
-    "react-syntax-highlighter": "^15.4.4",
+    "react-syntax-highlighter": "^15.4.5",
     "react-twitter-embed": "^3.0.3",
     "rimraf": "^3.0.2",
-    "sharp": "^0.29.2",
+    "sharp": "^0.29.3",
     "tailwindcss": "^2.2.19",
     "yup": "^0.32.11"
   },
@@ -92,7 +92,7 @@
     "prettier": "^2.4.1",
     "prop-types": "^15.7.2",
     "storybook-css-modules-preset": "^1.1.1",
-    "stylelint": "^14.0.1",
-    "stylelint-config-standard": "^23.0.0"
+    "stylelint": "^14.1.0",
+    "stylelint-config-standard": "^24.0.0"
   }
 }


### PR DESCRIPTION
Closes #762
Closes #763
Closes #764
Closes #765
Closes #766
Closes #767
Closes #768
Closes #769
Closes #770

https://nextjs-wordpress-starter-git-feature-depen-50fcff-webdevstudios.vercel.app/

### Description

This PR closes the following Node dependencies:

```bash
 react-syntax-highlighter   ^15.4.4  →  ^15.4.5     
 sharp                      ^0.29.2  →  ^0.29.3     
 stylelint                  ^14.0.1  →  ^14.1.0     
 stylelint-config-standard  ^23.0.0  →  ^24.0.0  
```

### Screenshot

![screenshot](https://dl.dropbox.com/s/7pnwqbw9b00eatj/Screen%20Shot%202021-11-15%20at%2007.56.58.png?dl=0)

### Verification

How will a stakeholder test this?

1. `gh pr checkout 771`
2. `npm i --legacy-peer-deps`
3. `npm run build && npm start`
4. Verify everything displays correctly
