### PR TITLE
Make col widths work

### DIFF
--- a/frontend/components/blocks/Gutenberg/BlockColumns/BlockColumns.js
+++ b/frontend/components/blocks/Gutenberg/BlockColumns/BlockColumns.js
@@ -28,13 +28,15 @@ export default function BlockColumns({
   innerBlocks,
   style,
   textColorHex,
-  verticalAlignment
+  verticalAlignment,
+  width,
 }) {
   const columnsStyle = getBlockStyles({
     backgroundColorHex,
     gradientHex,
     textColorHex,
-    style
+    style,
+    width
   })
 
   return (
@@ -85,5 +87,6 @@ BlockColumns.propTypes = {
   ),
   style: PropTypes.object,
   textColorHex: PropTypes.string,
-  verticalAlignment: PropTypes.string
+  verticalAlignment: PropTypes.string,
+  width: PropTypes.string
 }

--- a/frontend/functions/wordpress/blocks/getBlockStyles.js
+++ b/frontend/functions/wordpress/blocks/getBlockStyles.js
@@ -48,7 +48,7 @@ export default function getBlockStyles({
   }
 
   if (width) {
-    blockStyle.width = width ? `${width}%` : 'auto'
+    blockStyle.width = width ? `${width}` : 'auto'
   }
 
   return blockStyle


### PR DESCRIPTION
Fix that makes column widths actually come through. 

Column widths wouldnt come in through styles.
This also fixes and issue where when they would come through, they would have a % behind it, with the editor allowing for so many values this would break or double up % signs.



### Verification

How will a stakeholder test this?

1. Add a column block
2. Assign widths to each column
