### PR TITLE
Fix column width handling

### DIFF
--- a/frontend/components/atoms/Columns/Columns.module.css
+++ b/frontend/components/atoms/Columns/Columns.module.css
@@ -1,29 +1,5 @@
 .columns {
-  @apply grid gap-8 grid-cols-3;
-
-  &.columns-1 {
-    @apply grid-cols-1;
-  }
-
-  &.columns-2 {
-    @apply grid-cols-2;
-  }
-
-  &.columns-3 {
-    @apply grid-cols-3;
-  }
-
-  &.columns-4 {
-    @apply grid-cols-4;
-  }
-
-  &.columns-5 {
-    @apply grid-cols-5;
-  }
-
-  &.columns-6 {
-    @apply grid-cols-6;
-  }
+  @apply flex flex-row gap-8;
 
   &.alignCenter {
     & .column {

--- a/frontend/components/blocks/Gutenberg/BlockColumns/BlockColumns.js
+++ b/frontend/components/blocks/Gutenberg/BlockColumns/BlockColumns.js
@@ -28,15 +28,13 @@ export default function BlockColumns({
   innerBlocks,
   style,
   textColorHex,
-  verticalAlignment,
-  width,
+  verticalAlignment
 }) {
   const columnsStyle = getBlockStyles({
     backgroundColorHex,
     gradientHex,
     textColorHex,
-    style,
-    width
+    style
   })
 
   return (
@@ -54,7 +52,8 @@ export default function BlockColumns({
               backgroundColorHex: attributes?.backgroundColorHex,
               gradientHex: attributes?.gradientHex,
               textColorHex: attributes?.textColorHex,
-              style: attributes?.style
+              style: attributes?.style,
+              width: attributes?.width || '50%'
             })
 
             return (
@@ -87,6 +86,5 @@ BlockColumns.propTypes = {
   ),
   style: PropTypes.object,
   textColorHex: PropTypes.string,
-  verticalAlignment: PropTypes.string,
-  width: PropTypes.string
+  verticalAlignment: PropTypes.string
 }

--- a/frontend/components/blocks/Gutenberg/BlockColumns/BlockColumns.js
+++ b/frontend/components/blocks/Gutenberg/BlockColumns/BlockColumns.js
@@ -28,13 +28,15 @@ export default function BlockColumns({
   innerBlocks,
   style,
   textColorHex,
-  verticalAlignment
+  verticalAlignment,
+  width,
 }) {
   const columnsStyle = getBlockStyles({
     backgroundColorHex,
     gradientHex,
     textColorHex,
-    style
+    style,
+    width
   })
 
   return (
@@ -85,5 +87,6 @@ BlockColumns.propTypes = {
   ),
   style: PropTypes.object,
   textColorHex: PropTypes.string,
-  verticalAlignment: PropTypes.string
+  verticalAlignment: PropTypes.string,
+  width: PropTypes.string
 }

--- a/frontend/functions/wordpress/blocks/getBlockStyles.js
+++ b/frontend/functions/wordpress/blocks/getBlockStyles.js
@@ -2,13 +2,13 @@
  * Get formatted block styles.
  *
  * @author WebDevStudios
- * @param  {object} styles                    Various block custom and preset styles.
- * @param  {string} styles.backgroundColorHex The background color hex value.
- * @param  {string} styles.gradientHex        The background gradient hex value.
- * @param  {string} styles.textColorHex       The text color hex value.
- * @param  {number} styles.width              The width in percent.
- * @param  {object} styles.style              The style attributes.
- * @return {object}                           The formatted style object.
+ * @param  {object}          styles                    Various block custom and preset styles.
+ * @param  {string}          styles.backgroundColorHex The background color hex value.
+ * @param  {string}          styles.gradientHex        The background gradient hex value.
+ * @param  {string}          styles.textColorHex       The text color hex value.
+ * @param  {number | string} styles.width              The block width.
+ * @param  {object}          styles.style              The style attributes.
+ * @return {object}                                    The formatted style object.
  */
 export default function getBlockStyles({
   backgroundColorHex,
@@ -48,7 +48,13 @@ export default function getBlockStyles({
   }
 
   if (width) {
-    blockStyle.width = width ? `${width}` : 'auto'
+    if (isNaN(width)) {
+      // If width is not a number, return full string.
+      blockStyle.width = width
+    } else {
+      // If width is a number, return as percent.
+      blockStyle.width = `${width}%`
+    }
   }
 
   return blockStyle

--- a/frontend/functions/wordpress/blocks/getBlockStyles.js
+++ b/frontend/functions/wordpress/blocks/getBlockStyles.js
@@ -48,7 +48,7 @@ export default function getBlockStyles({
   }
 
   if (width) {
-    blockStyle.width = width ? `${width}%` : 'auto'
+    blockStyle.width = width ? `${width}` : 'auto'
   }
 
   return blockStyle


### PR DESCRIPTION
Closes #797

### Description

Expands on the work done in #797 to fix inner column block width handling.

### Screenshot

![Screenshot 2021-12-23 at 11-04-02 column widths - Next js WordPress Starter](https://user-images.githubusercontent.com/36422618/147277363-98eb62bb-c2d8-4adb-aca1-44f13d81fa03.png)

### Verification

[blog/797-columns-fix](https://nextjs-wordpress-starter-cc28nwemy-webdevstudios.vercel.app/blog/797-columns-fix)