### PR TITLE
feature/634-button-external

### DIFF
--- a/frontend/components/blocks/Gutenberg/BlockButton/BlockButton.js
+++ b/frontend/components/blocks/Gutenberg/BlockButton/BlockButton.js
@@ -48,7 +48,9 @@ export default function BlockButton({
   })
 
   // Add additional styles.
-  buttonStyle.borderRadius = `${borderRadius}px`
+  if (borderRadius) {
+    buttonStyle.borderRadius = `${borderRadius}px`
+  }
 
   // Extract button style.
   const styleOutline = className && className.includes('is-style-outline')

--- a/frontend/components/blocks/Gutenberg/BlockButton/BlockButton.js
+++ b/frontend/components/blocks/Gutenberg/BlockButton/BlockButton.js
@@ -20,6 +20,7 @@ import PropTypes from 'prop-types'
  * @param  {string}  props.text               The link label.
  * @param  {string}  props.textColorHex       The text color hex value.
  * @param  {string}  props.url                The link for the button.
+ * @param  {boolean} props.urlExternal        Whether link is external.
  * @param  {number}  props.width              The width in percent.
  * @return {Element}                          The Button component.
  */
@@ -35,6 +36,7 @@ export default function BlockButton({
   text,
   textColorHex,
   url,
+  urlExternal,
   width
 }) {
   const buttonStyle = getBlockStyles({
@@ -67,7 +69,7 @@ export default function BlockButton({
       styleOutline={styleOutline}
       text={text}
       url={url}
-      urlExternal={true}
+      urlExternal={urlExternal}
     />
   )
 }
@@ -84,5 +86,6 @@ BlockButton.propTypes = {
   text: PropTypes.string,
   textColorHex: PropTypes.string,
   url: PropTypes.string,
+  urlExternal: PropTypes.bool,
   width: PropTypes.number
 }


### PR DESCRIPTION
Closes #634 
Closes https://github.com/WebDevStudios/wds-headless-wordpress/issues/24

### Description

Handles custom `urlExternal` attr in core button block
Adds check to avoid returning styles with `undefinedpx` for border radius

### Screenshot

n/a

### Verification

1. update local to use latest `wds-headless-core` plugin version
2. create a post/page with core/buttons block with several buttons, some with external links and some with internal site links
3. view post on frontend to ensure `border-radius` does not display unless set

`urlExternal` does not appear to have a visible effect on the frontend
