### PR TITLE
Fix/568 env var for graphql

### DIFF
--- a/docs/docs/frontend/env-variables.md
+++ b/docs/docs/frontend/env-variables.md
@@ -68,6 +68,11 @@ NEXT_PUBLIC_IMAGE_DOMAINS="nextjs.wpengine.com, nextjsdevstart.wpengine.com, nex
 NEXTAUTH_URL="https://nextjs.wpengine.com/"
 ```
 
+```text
+# Your WordPress GraphQL endpoint (optional, will default to "graphql" if not provided).
+WORDPRESS_GRAPHQL_ENDPOINT="graphql"
+```
+
 ## Add ENV Variables to Frontend Hosting
 
 Eventually, you'll need to add your ENV Variables to your host. The host needs these variables in order to run a build.

--- a/frontend/lib/wordpress/connector.js
+++ b/frontend/lib/wordpress/connector.js
@@ -5,6 +5,8 @@ import {useMemo} from 'react'
 // Define env vars.
 export const wpApiUrlBase = process.env.WORDPRESS_URL
 export const wpPreviewSecret = process.env.WORDPRESS_PREVIEW_SECRET
+export const graphQlEndpoint =
+  process.env.WORDPRESS_GRAPHQL_ENDPOINT || 'graphql'
 const wpAppUser = process.env.WORDPRESS_APPLICATION_USERNAME
 const wpAppPass = process.env.WORDPRESS_APPLICATION_PASSWORD
 
@@ -27,7 +29,7 @@ export function createWpApolloClient(auth = false) {
   return new ApolloClient({
     ssrMode: false,
     link: new HttpLink({
-      uri: `${wpApiUrlBase}graphql`,
+      uri: `${wpApiUrlBase}${graphQlEndpoint}`,
       credentials: '',
       headers: {
         authorization: auth ? `Basic ${wpAuthorization}` : ''


### PR DESCRIPTION
Closes #568

### Description

Adds handling for optional env var to customize WP GraphQL endpoint

### Screenshot

n/a

### Verification

if your local WP GraphQL endpoint is '/graphql':
1. `gh pr checkout 806`
2. `npm run dev`
3. http://localhost:3000/ - ensure site builds as normal (without env var set)

if your local WP GraphQL endpoint is something else:
1. `gh pr checkout 806`
2. update `.env` to add `WORDPRESS_GRAPHQL_ENDPOINT=<your endpoint>` (no leading slash)
3. `npm run dev`
4. http://localhost:3000/ - ensure site builds as expected
