### PR TITLE
Fix/635 404 handling

### DIFF
--- a/frontend/functions/wordpress/postTypes/getHeadlessConfigPage.js
+++ b/frontend/functions/wordpress/postTypes/getHeadlessConfigPage.js
@@ -9,10 +9,12 @@ import headlessConfigPageQuerySeo from '@/lib/wordpress/_config/headlessConfigPa
  * @return {object}      Object containing Apollo client instance and post data or error object.
  */
 export default async function getHeadlessConfigPage(page) {
-  // Retrieve page query.
-  const query = headlessConfigPageQuerySeo?.[page]?.query ?? null
+  // Retrieve page config.
+  const config = headlessConfigPageQuerySeo?.[page]
+  const query = config?.query ?? null
+  const type = config?.type || 'page'
 
-  const data = await processPostTypeQuery('page', page, query)
+  const data = await processPostTypeQuery(type, page, query)
 
   // Add custom SEO if missing.
   if (!data?.post?.seo) {

--- a/frontend/functions/wordpress/postTypes/processPostTypeQuery.js
+++ b/frontend/functions/wordpress/postTypes/processPostTypeQuery.js
@@ -60,7 +60,7 @@ export default async function processPostTypeQuery(
       // Retrieve post data.
       let post =
         postData?.[postType] ?? // Dynamic posts.
-        postData?.additionalSettings?.additionalSettings?.[postType] // Settings custom page.
+        postData?.headlessConfig?.additionalSettings?.[postType] // Settings custom page.
 
       // Set error props if data not found.
       if (!post) {

--- a/frontend/lib/wordpress/_config/headlessConfigPageQuerySeo.js
+++ b/frontend/lib/wordpress/_config/headlessConfigPageQuerySeo.js
@@ -4,6 +4,7 @@ import queryError404Page from '@/lib/wordpress/pages/queryError404Page'
 const headlessConfigPageQuerySeo = {
   404: {
     query: queryError404Page,
+    type: 'error404Page',
     title: '404 Not Found',
     description: ''
   }


### PR DESCRIPTION
Relates to #635

### Description

Fixes FE handling for 404 page (it was apparently already broken)

### Screenshot

![Screenshot 2021-12-30 at 12-06-16 404 Not Found - Next js WordPress Starter](https://user-images.githubusercontent.com/36422618/147781127-89b7f329-1d3a-4cbc-bc9d-c1a80775d83a.png)

### Verification

https://nextjs-wordpress-starter-5tj72221t-webdevstudios.vercel.app/aslkdfj
