### PR TITLE
Fix/779 previews

### DIFF
--- a/frontend/functions/wordpress/postTypes/getPostTypeStaticProps.js
+++ b/frontend/functions/wordpress/postTypes/getPostTypeStaticProps.js
@@ -132,15 +132,15 @@ export default async function getPostTypeStaticProps(
   /* -- Handle dynamic posts. -- */
 
   // Get post identifier (ID or slug).
-  const postId = Number.isInteger(Number(slug))
-    ? Number(slug)
-    : slug.replace(/^\/|\/$/g, '')
+  const postId = Number.isInteger(Number(slug)) ? Number(slug) : slug
 
   // Check if preview mode is active and valid for current post (preview and post IDs or slugs match).
   const isCurrentPostPreview =
     preview &&
     (postId === previewData?.post?.id ||
-      postId === previewData?.post?.uri?.replace(/^\/|\/$/g, ''))
+      // Compare URIs with leading and trailing slashes stripped.
+      postId.replace(/^\/|\/$/g, '') ===
+        previewData?.post?.uri?.replace(/^\/|\/$/g, ''))
 
   // Check if viewing a draft post.
   const isDraft = isCurrentPostPreview && 'draft' === previewData?.post?.status

--- a/frontend/functions/wordpress/postTypes/getPostTypeStaticProps.js
+++ b/frontend/functions/wordpress/postTypes/getPostTypeStaticProps.js
@@ -132,12 +132,15 @@ export default async function getPostTypeStaticProps(
   /* -- Handle dynamic posts. -- */
 
   // Get post identifier (ID or slug).
-  const postId = Number.isInteger(Number(slug)) ? Number(slug) : slug
+  const postId = Number.isInteger(Number(slug))
+    ? Number(slug)
+    : slug.replace(/^\/|\/$/g, '')
 
   // Check if preview mode is active and valid for current post (preview and post IDs or slugs match).
   const isCurrentPostPreview =
     preview &&
-    (postId === previewData?.post?.id || postId === previewData?.post?.slug)
+    (postId === previewData?.post?.id ||
+      postId === previewData?.post?.uri?.replace(/^\/|\/$/g, ''))
 
   // Check if viewing a draft post.
   const isDraft = isCurrentPostPreview && 'draft' === previewData?.post?.status

--- a/frontend/pages/api/preview.js
+++ b/frontend/pages/api/preview.js
@@ -46,7 +46,8 @@ export default async function preview(req, res) {
       post: {
         id: post.databaseId,
         slug: post.slug,
-        status: post.status
+        status: post.status,
+        uri: post.uri
       }
     })
 

--- a/frontend/pages/api/preview.js
+++ b/frontend/pages/api/preview.js
@@ -55,7 +55,7 @@ export default async function preview(req, res) {
 
     // Redirect to post dynamic route.
     res.redirect(
-      post.slug
+      post.slug && post.uri && post.uri.indexOf('?page_id=') === -1
         ? post.uri
         : `${baseRoute ? `/${baseRoute}` : ''}/${post.databaseId}`
     )

--- a/frontend/pages/api/preview.js
+++ b/frontend/pages/api/preview.js
@@ -54,7 +54,9 @@ export default async function preview(req, res) {
 
     // Redirect to post dynamic route.
     res.redirect(
-      `${baseRoute ? `/${baseRoute}` : ''}/${post.slug || post.databaseId}`
+      post.slug
+        ? post.uri
+        : `${baseRoute ? `/${baseRoute}` : ''}/${post.databaseId}`
     )
   } catch (error) {
     return res.status(error?.status || 401).json({


### PR DESCRIPTION
Closes #779

### Description

Fixes post previews by using URI instead of slug, so nested/hierarchical routes don't break.

### Screenshot

![Screen Shot 2021-12-30 at 2 29 18 PM](https://user-images.githubusercontent.com/36422618/147789164-19dea85d-526a-469d-a7a8-c093ae6564cb.png)

### Verification

1. draft post: https://nextjs-wordpress-starter-69hxu64xm-webdevstudios.vercel.app/api/preview?name=634-buttons-with-external-links&id=509&post_type=post&token=wlslYxY46280pcNrtZNG8waw
2. published post: https://nextjs-wordpress-starter-69hxu64xm-webdevstudios.vercel.app/api/preview?name=410-heading-block-enhancements&id=478&post_type=post&token=wlslYxY46280pcNrtZNG8waw
3. draft page: https://nextjs-wordpress-starter-69hxu64xm-webdevstudios.vercel.app/api/preview?name=privacy-policy&id=3&post_type=page&token=wlslYxY46280pcNrtZNG8waw
4. published page: https://nextjs-wordpress-starter-69hxu64xm-webdevstudios.vercel.app/api/preview?name=careers&id=379&post_type=page&token=wlslYxY46280pcNrtZNG8waw
