### PR TITLE
Feature/849 500 error page

### DIFF
--- a/frontend/functions/wordpress/postTypes/getPostTypeStaticProps.js
+++ b/frontend/functions/wordpress/postTypes/getPostTypeStaticProps.js
@@ -167,7 +167,7 @@ export default async function getPostTypeStaticProps(
   const idType = isDraft ? 'DATABASE_ID' : 'SLUG'
 
   // Retrieve post data.
-  const {apolloClient, error, errorMessage, ...postData} =
+  const {apolloClient, error, errorMessage, notFound, ...postData} =
     await getPostTypeById(
       postType,
       id,
@@ -200,10 +200,15 @@ export default async function getPostTypeStaticProps(
     preview: isCurrentPostPreview
   }
 
-  // Fallback to empty props if homepage not set in WP.
-  if ('/' === slug && error) {
+  if ('/' === slug && notFound === true) {
+    // Fallback to empty props if homepage not set in WP.
     props.post = null
     props.error = false
+  } else if (notFound) {
+    // Return 404 if any other page is not found.
+    return {
+      notFound: true
+    }
   }
 
   // Merge in query results as Apollo state.

--- a/frontend/functions/wordpress/postTypes/getPostTypeStaticProps.js
+++ b/frontend/functions/wordpress/postTypes/getPostTypeStaticProps.js
@@ -167,12 +167,13 @@ export default async function getPostTypeStaticProps(
   const idType = isDraft ? 'DATABASE_ID' : 'SLUG'
 
   // Retrieve post data.
-  const {apolloClient, error, ...postData} = await getPostTypeById(
-    postType,
-    id,
-    idType,
-    isCurrentPostPreview ? 'full' : null
-  )
+  const {apolloClient, error, errorMessage, ...postData} =
+    await getPostTypeById(
+      postType,
+      id,
+      idType,
+      isCurrentPostPreview ? 'full' : null
+    )
 
   // Check if dealing with posts page.
   if (postType === 'page' && postData?.post?.isPostsPage) {
@@ -195,6 +196,7 @@ export default async function getPostTypeStaticProps(
     ...postData,
     ...sharedProps,
     error,
+    errorMessage,
     preview: isCurrentPostPreview
   }
 
@@ -202,13 +204,6 @@ export default async function getPostTypeStaticProps(
   if ('/' === slug && error) {
     props.post = null
     props.error = false
-  }
-
-  // Display 404 error page if error encountered.
-  if (props.error) {
-    return {
-      notFound: true
-    }
   }
 
   // Merge in query results as Apollo state.

--- a/frontend/functions/wordpress/postTypes/processPostTypeQuery.js
+++ b/frontend/functions/wordpress/postTypes/processPostTypeQuery.js
@@ -62,10 +62,9 @@ export default async function processPostTypeQuery(
         postData?.[postType] ?? // Dynamic posts.
         postData?.headlessConfig?.additionalSettings?.[postType] // Settings custom page.
 
-      // Set error props if data not found.
+      // Set notFound prop if post data missing.
       if (!post) {
-        response.error = true
-        response.errorMessage = `An error occurred while trying to retrieve data for ${postType} "${id}."`
+        response.notFound = true
 
         return null
       }

--- a/frontend/lib/wordpress/_config/frontendPageSeo.js
+++ b/frontend/lib/wordpress/_config/frontendPageSeo.js
@@ -1,5 +1,9 @@
 // Define SEO for Frontend routes.
 const frontendPageSeo = {
+  500: {
+    title: '500',
+    description: 'Server-side error occurred'
+  },
   search: {
     title: 'Search',
     description: 'Search page'

--- a/frontend/pages/500.js
+++ b/frontend/pages/500.js
@@ -1,0 +1,54 @@
+import Code from '@/components/atoms/Code'
+import Container from '@/components/atoms/Container'
+import RichText from '@/components/atoms/RichText'
+import Layout from '@/components/common/Layout'
+import getPagePropTypes from '@/functions/getPagePropTypes'
+import getPostTypeStaticProps from '@/functions/wordpress/postTypes/getPostTypeStaticProps'
+import PropTypes from 'prop-types'
+
+// Define route post type.
+const postType = '500'
+
+/**
+ * Render the Custom500 component.
+ *
+ * @author WebDevStudios
+ * @param  {object}  props              The component attributes as props.
+ * @param  {string}  props.errorMessage The 500 error message.
+ * @param  {object}  props.post         Post data from WordPress.
+ * @return {Element}                    The Custom500 component.
+ */
+export default function Custom500({errorMessage, post}) {
+  const {seo = {}} = post
+
+  // Update robots SEO meta.
+  seo.metaRobotsNofollow = 'noindex'
+  seo.metaRobotsNoindex = 'nofollow'
+
+  return (
+    <Layout seo={{...seo}}>
+      <Container>
+        <article>
+          <RichText tag="h1">500 Error</RichText>
+          <p>A server-side error has occurred.</p>
+          {errorMessage && <Code content={errorMessage} />}
+        </article>
+      </Container>
+    </Layout>
+  )
+}
+
+/**
+ * Get post static props.
+ *
+ * @author WebDevStudios
+ * @return {object} Post props.
+ */
+export async function getStaticProps() {
+  return await getPostTypeStaticProps(null, postType)
+}
+
+Custom500.propTypes = {
+  ...getPagePropTypes(postType),
+  errorMessage: PropTypes.string
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -4,11 +4,11 @@ import '@/styles/demo.css'
 import '@/styles/index.css'
 import {ApolloProvider} from '@apollo/client'
 import {SessionProvider as NextAuthProvider} from 'next-auth/react'
-import Error from 'next/error'
 import Link from 'next/link'
 import PropTypes from 'prop-types'
 import {useState} from 'react'
 import 'tailwindcss/tailwind.css'
+import Custom500 from './500'
 
 /**
  * Render the App component.
@@ -69,7 +69,7 @@ export default function App({Component, pageProps}) {
       <ApolloProvider client={apolloClient}>
         <WordPressProvider value={wp}>
           {error ? (
-            <Error statusCode={500} title={errorMessage} />
+            <Custom500 errorMessage={errorMessage} post={componentProps.post} />
           ) : (
             <>
               {!!preview && (


### PR DESCRIPTION
Closes #849
Closes #155 

### Description

Adds custom 500 error page
Updates 404 handling to properly show 500 errors when present (this addresses #155, which is fixed now that we're using a different permalink structure)

### Screenshot

![Screenshot 2022-01-14 at 11-07-15 500 - Next js WordPress Starter](https://user-images.githubusercontent.com/36422618/149563986-5226f9f7-89e7-4e74-897c-3ada43961f7a.png)

![Screenshot 2022-01-14 at 11-14-03 Screenshot](https://user-images.githubusercontent.com/36422618/149566138-3962b93d-828d-4dd7-b200-4274db86c6d8.png)

### Verification

1. 500: https://nextjs-wordpress-starter-i44g7r62f-webdevstudios.vercel.app/2021/09/1sldkfj
2. 404: https://nextjs-wordpress-starter-i44g7r62f-webdevstudios.vercel.app/sdf
