### PR TITLE
Feature/872 trailing slash

### DIFF
--- a/docs/docs/frontend/env-variables.md
+++ b/docs/docs/frontend/env-variables.md
@@ -23,7 +23,7 @@ NODE_TLS_REJECT_UNAUTHORIZED="0"
 ```
 
 ```text
-# Your WordPress URL.
+# Your WordPress URL (with or without trailing slash).
 WORDPRESS_URL="https://nextjs.wpengine.com/"
 ```
 

--- a/frontend/functions/wordpress/postTypes/getPostTypeStaticProps.js
+++ b/frontend/functions/wordpress/postTypes/getPostTypeStaticProps.js
@@ -167,12 +167,13 @@ export default async function getPostTypeStaticProps(
   const idType = isDraft ? 'DATABASE_ID' : 'SLUG'
 
   // Retrieve post data.
-  const {apolloClient, error, ...postData} = await getPostTypeById(
-    postType,
-    id,
-    idType,
-    isCurrentPostPreview ? 'full' : null
-  )
+  const {apolloClient, error, errorMessage, notFound, ...postData} =
+    await getPostTypeById(
+      postType,
+      id,
+      idType,
+      isCurrentPostPreview ? 'full' : null
+    )
 
   // Check if dealing with posts page.
   if (postType === 'page' && postData?.post?.isPostsPage) {
@@ -195,17 +196,16 @@ export default async function getPostTypeStaticProps(
     ...postData,
     ...sharedProps,
     error,
+    errorMessage,
     preview: isCurrentPostPreview
   }
 
-  // Fallback to empty props if homepage not set in WP.
-  if ('/' === slug && error) {
+  if ('/' === slug && notFound === true) {
+    // Fallback to empty props if homepage not set in WP.
     props.post = null
     props.error = false
-  }
-
-  // Display 404 error page if error encountered.
-  if (props.error) {
+  } else if (notFound) {
+    // Return 404 if any other page is not found.
     return {
       notFound: true
     }

--- a/frontend/functions/wordpress/postTypes/processPostTypeQuery.js
+++ b/frontend/functions/wordpress/postTypes/processPostTypeQuery.js
@@ -62,10 +62,9 @@ export default async function processPostTypeQuery(
         postData?.[postType] ?? // Dynamic posts.
         postData?.headlessConfig?.additionalSettings?.[postType] // Settings custom page.
 
-      // Set error props if data not found.
+      // Set notFound prop if post data missing.
       if (!post) {
-        response.error = true
-        response.errorMessage = `An error occurred while trying to retrieve data for ${postType} "${id}."`
+        response.notFound = true
 
         return null
       }

--- a/frontend/lib/wordpress/_config/frontendPageSeo.js
+++ b/frontend/lib/wordpress/_config/frontendPageSeo.js
@@ -1,5 +1,9 @@
 // Define SEO for Frontend routes.
 const frontendPageSeo = {
+  500: {
+    title: '500',
+    description: 'Server-side error occurred'
+  },
   search: {
     title: 'Search',
     description: 'Search page'

--- a/frontend/lib/wordpress/connector.js
+++ b/frontend/lib/wordpress/connector.js
@@ -3,7 +3,8 @@ import {ApolloClient, HttpLink, InMemoryCache} from '@apollo/client'
 import {useMemo} from 'react'
 
 // Define env vars.
-export const wpApiUrlBase = process.env.WORDPRESS_URL
+export const wpApiUrlBase =
+  process.env.WORDPRESS_URL?.replace(/\/?$/, '/') || '/'
 export const wpPreviewSecret = process.env.WORDPRESS_PREVIEW_SECRET
 export const graphQlEndpoint =
   process.env.WORDPRESS_GRAPHQL_ENDPOINT || 'graphql'

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  trailingSlash: true,
   swcMinify: true,
   images: {
     domains: process.env.NEXT_PUBLIC_IMAGE_DOMAINS.split(', ')

--- a/frontend/pages/500.js
+++ b/frontend/pages/500.js
@@ -1,0 +1,54 @@
+import Code from '@/components/atoms/Code'
+import Container from '@/components/atoms/Container'
+import RichText from '@/components/atoms/RichText'
+import Layout from '@/components/common/Layout'
+import getPagePropTypes from '@/functions/getPagePropTypes'
+import getPostTypeStaticProps from '@/functions/wordpress/postTypes/getPostTypeStaticProps'
+import PropTypes from 'prop-types'
+
+// Define route post type.
+const postType = '500'
+
+/**
+ * Render the Custom500 component.
+ *
+ * @author WebDevStudios
+ * @param  {object}  props              The component attributes as props.
+ * @param  {string}  props.errorMessage The 500 error message.
+ * @param  {object}  props.post         Post data from WordPress.
+ * @return {Element}                    The Custom500 component.
+ */
+export default function Custom500({errorMessage, post}) {
+  const {seo = {}} = post
+
+  // Update robots SEO meta.
+  seo.metaRobotsNofollow = 'noindex'
+  seo.metaRobotsNoindex = 'nofollow'
+
+  return (
+    <Layout seo={{...seo}}>
+      <Container>
+        <article>
+          <RichText tag="h1">500 Error</RichText>
+          <p>A server-side error has occurred.</p>
+          {errorMessage && <Code content={errorMessage} />}
+        </article>
+      </Container>
+    </Layout>
+  )
+}
+
+/**
+ * Get post static props.
+ *
+ * @author WebDevStudios
+ * @return {object} Post props.
+ */
+export async function getStaticProps() {
+  return await getPostTypeStaticProps(null, postType)
+}
+
+Custom500.propTypes = {
+  ...getPagePropTypes(postType),
+  errorMessage: PropTypes.string
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -4,11 +4,11 @@ import '@/styles/demo.css'
 import '@/styles/index.css'
 import {ApolloProvider} from '@apollo/client'
 import {SessionProvider as NextAuthProvider} from 'next-auth/react'
-import Error from 'next/error'
 import Link from 'next/link'
 import PropTypes from 'prop-types'
 import {useState} from 'react'
 import 'tailwindcss/tailwind.css'
+import Custom500 from './500'
 
 /**
  * Render the App component.
@@ -69,7 +69,7 @@ export default function App({Component, pageProps}) {
       <ApolloProvider client={apolloClient}>
         <WordPressProvider value={wp}>
           {error ? (
-            <Error statusCode={500} title={errorMessage} />
+            <Custom500 errorMessage={errorMessage} post={componentProps.post} />
           ) : (
             <>
               {!!preview && (


### PR DESCRIPTION
Closes #872

**Note: #871 must be merged first**

### Description

Updates next.config to prefer/redirect to trailing slash URLs
Updates handling of `WORDPRESS_URL` env var to support with and without trailing slash
Updates docs to refer to support for `WORDPRESS_URL` with and without trailing slash

### Screenshot

without current changes, if `WORDPRESS_URL` is missing trailing slash:
![Screenshot 2022-01-14 at 14-20-32 Screenshot](https://user-images.githubusercontent.com/36422618/149587975-ca0a6a32-c781-4f37-aeae-4822460ac895.png)

### Verification

1. `gh pr checkout 873`
2. update `WORDPRESS_URL` to remove trailing slash
3. `npm run dev` - site should load as normal
4. stop dev, update `WORDPRESS_URL` to include trailing slash
5. `npm run dev` - site should still load
