### PR TITLE
Hotfix/885 column width

### DIFF
--- a/components/atoms/Columns/Columns.js
+++ b/components/atoms/Columns/Columns.js
@@ -13,6 +13,7 @@ import styles from './Columns.module.css'
  * @param  {object}  props.children          React children.
  * @param  {object}  props.style             Custom columns styles.
  * @param  {string}  props.verticalAlignment Vertical alignment of columns.
+ * @param    {boolean}        props.isStackedOnMobile Checks if the columns are stacked.
  * @return {Element}                         The Columns component.
  */
 export default function Columns({

--- a/components/atoms/Columns/Columns.js
+++ b/components/atoms/Columns/Columns.js
@@ -21,13 +21,15 @@ export default function Columns({
   columnCount,
   children,
   style,
-  verticalAlignment
+  verticalAlignment,
+  isStackedOnMobile
 }) {
   return (
     <div
       id={id || null}
       className={cn(
         styles.columns,
+        isStackedOnMobile && styles.columnStacked,
         columnCount && styles[`columns-${columnCount}`],
         className,
         verticalAlignment === 'center' ? styles.alignCenter : null,

--- a/components/atoms/Columns/Columns.js
+++ b/components/atoms/Columns/Columns.js
@@ -13,7 +13,7 @@ import styles from './Columns.module.css'
  * @param  {object}  props.children          React children.
  * @param  {object}  props.style             Custom columns styles.
  * @param  {string}  props.verticalAlignment Vertical alignment of columns.
- * @param    {boolean}        props.isStackedOnMobile Checks if the columns are stacked.
+ * @param  {boolean} props.isStackedOnMobile Checks if the columns are stacked.
  * @return {Element}                         The Columns component.
  */
 export default function Columns({

--- a/components/atoms/Columns/Columns.module.css
+++ b/components/atoms/Columns/Columns.module.css
@@ -1,5 +1,9 @@
 .columns {
-  @apply flex flex-row gap-8;
+  @apply flex gap-8;
+
+  &.columnStacked {
+    @apply flex-col md:flex-row;
+  }
 
   &.alignCenter {
     & .column {
@@ -18,7 +22,7 @@
   }
 
   & .column {
-    @apply flex flex-col;
+    @apply flex flex-col w-full;
 
     &.hasBackground {
       @apply p-4;

--- a/components/blocks/core/BlockColumns/BlockColumns.js
+++ b/components/blocks/core/BlockColumns/BlockColumns.js
@@ -17,7 +17,7 @@ import PropTypes from 'prop-types'
  * @param  {object}  props.innerBlocks        The array of inner blocks to display.
  * @param  {object}  props.style              The style attributes.
  * @param  {string}  props.textColorHex       The text color hex value.
- * @param    {boolean}        props.isStackedOnMobile Checks if the columns are stacked.
+ * @param  {boolean} props.isStackedOnMobile  Checks if the columns are stacked.
  * @param  {string}  props.verticalAlignment  Vertical alignment of columns.
  * @return {Element}                          The Columns component.
  */

--- a/components/blocks/core/BlockColumns/BlockColumns.js
+++ b/components/blocks/core/BlockColumns/BlockColumns.js
@@ -28,7 +28,8 @@ export default function BlockColumns({
   innerBlocks,
   style,
   textColorHex,
-  verticalAlignment
+  verticalAlignment,
+  isStackedOnMobile
 }) {
   const columnsStyle = getBlockStyles({
     backgroundColorHex,
@@ -46,6 +47,7 @@ export default function BlockColumns({
           columnCount={innerBlocks?.length}
           style={columnsStyle}
           verticalAlignment={verticalAlignment}
+          isStackedOnMobile={isStackedOnMobile}
         >
           {innerBlocks.map(({attributes, innerBlocks}, index) => {
             const columnStyle = getBlockStyles({
@@ -53,7 +55,7 @@ export default function BlockColumns({
               gradientHex: attributes?.gradientHex,
               textColorHex: attributes?.textColorHex,
               style: attributes?.style,
-              width: attributes?.width || '50%'
+              width: attributes?.width
             })
 
             return (

--- a/components/blocks/core/BlockColumns/BlockColumns.js
+++ b/components/blocks/core/BlockColumns/BlockColumns.js
@@ -17,6 +17,7 @@ import PropTypes from 'prop-types'
  * @param  {object}  props.innerBlocks        The array of inner blocks to display.
  * @param  {object}  props.style              The style attributes.
  * @param  {string}  props.textColorHex       The text color hex value.
+ * @param    {boolean}        props.isStackedOnMobile Checks if the columns are stacked.
  * @param  {string}  props.verticalAlignment  Vertical alignment of columns.
  * @return {Element}                          The Columns component.
  */


### PR DESCRIPTION
Closes #885 

### Description

Adds `isStackedOnMobile` check and stacks columns on mobile at their full width.

### Screenshot
First column below is not stacked on mobile, second column block is. Border was just applied to illustrate width.

![image](https://user-images.githubusercontent.com/66800579/155355544-060d5cd8-dd69-4f58-8aa2-d2dc866740bf.png)


### Verification

1. `git checkout hotfix/885-column-width && npm run dev`
2. Create a column block, make sure `isStackedOnMobile` is selected
3. Check that the columns are using full width.