### PR TITLE
not working, switching branches

### DIFF
--- a/components/organisms/Archive/Archive.js
+++ b/components/organisms/Archive/Archive.js
@@ -29,6 +29,7 @@ export default function Archive({
   taxonomy,
   term
 }) {
+  // console.log('ARCHIVE')
   // Track all posts, including initial posts and additionally loaded pages.
   const [allPosts, setAllPosts] = useState(posts)
 

--- a/functions/wordpress/postTypes/getPostTypeArchive.js
+++ b/functions/wordpress/postTypes/getPostTypeArchive.js
@@ -31,6 +31,8 @@ export default async function getPostTypeArchive(
   // Get/create Apollo instance.
   const apolloClient = initializeWpApollo()
 
+  // console.log('JR POSTTYPEARCHIVE')
+
   // Set up return object.
   const response = {
     apolloClient,

--- a/functions/wordpress/postTypes/getPostTypeById.js
+++ b/functions/wordpress/postTypes/getPostTypeById.js
@@ -1,6 +1,7 @@
 import isHierarchicalPostType from '@/functions/wordpress/postTypes/isHierarchicalPostType'
 import processPostTypeQuery from '@/functions/wordpress/postTypes/processPostTypeQuery'
 import queryPageById from '@/lib/wordpress/pages/queryPageById'
+import constructCPTQuery from '@/lib/wordpress/posts/queryCPTById'
 import queryPostById from '@/lib/wordpress/posts/queryPostById'
 
 /**
@@ -20,7 +21,7 @@ export default async function getPostTypeById(
   preview = null
 ) {
   // Define single post query based on post type.
-  const postTypeQuery = {
+  let postTypeQuery = {
     page: queryPageById,
     post: queryPostById
   }
@@ -28,6 +29,11 @@ export default async function getPostTypeById(
   // Check if post type is hierarchical.
   const isHierarchical = isHierarchicalPostType(postType)
 
+  if (!isHierarchical) {
+    postTypeQuery[postType] = constructCPTQuery(postType)
+  }
+
+  // console.log('jr postType query', postTypeQuery)
   // Fix default ID type for hierarchical posts.
   idType = !isHierarchical || 'SLUG' !== idType ? idType : 'URI'
 

--- a/functions/wordpress/postTypes/getPostTypeStaticProps.js
+++ b/functions/wordpress/postTypes/getPostTypeStaticProps.js
@@ -34,6 +34,7 @@ export default async function getPostTypeStaticProps(
     }
   }
 
+  // console.log('--------line 37---------------')
   /* -- Handle Frontend-only routes. -- */
   if (Object.keys(frontendPageSeo).includes(postType)) {
     const {apolloClient, ...routeData} = await getFrontendPage(postType)
@@ -61,7 +62,8 @@ export default async function getPostTypeStaticProps(
         }
   }
 
-  /* -- Handle dynamic archive display. -- */
+  // console.log('--------line 68---------------')
+  // /* -- Handle dynamic archive display. -- */
   if (!Object.keys(params).length) {
     const {apolloClient, ...archiveData} = await getPostTypeArchive(postType)
 
@@ -76,6 +78,7 @@ export default async function getPostTypeStaticProps(
     })
   }
 
+  // console.log('--------line 81---------------')
   /* -- Handle date-based archives. -- */
   const year =
     Array.isArray(params?.slug) &&
@@ -95,6 +98,8 @@ export default async function getPostTypeStaticProps(
     !isNaN(params?.slug?.[2]) &&
     parseInt(params?.slug?.[2], 10)
   const isDateArchive = postType === 'page' && (year || month || day)
+  // console.log('--------line 101---------------')
+  // console.log('postType', postType)
 
   if (isDateArchive) {
     const {apolloClient, ...archiveData} = await getPostsDateArchive(
@@ -103,6 +108,9 @@ export default async function getPostTypeStaticProps(
       month ?? null,
       day ?? null
     )
+    // console.log('--------line 110---------------')
+    // console.log('archiveData', archiveData)
+    // console.log('sharedProps', sharedProps)
 
     // Merge in query results as Apollo state.
     return addApolloState(apolloClient, {
@@ -117,6 +125,7 @@ export default async function getPostTypeStaticProps(
       revalidate
     })
   }
+  // console.log('--------line 124---------------')
 
   /* -- Handle individual posts. -- */
 
@@ -145,6 +154,7 @@ export default async function getPostTypeStaticProps(
       revalidate
     })
   }
+  // console.log('--------line 151---------------')
 
   /* -- Handle dynamic posts. -- */
 
@@ -161,6 +171,7 @@ export default async function getPostTypeStaticProps(
 
   // Check if viewing a draft post.
   const isDraft = isCurrentPostPreview && 'draft' === previewData?.post?.status
+  // console.log('--------line 168---------------')
 
   // Set query variables.
   const id = isDraft ? previewData.post.id : slug

--- a/functions/wordpress/postTypes/processPostTypeQuery.js
+++ b/functions/wordpress/postTypes/processPostTypeQuery.js
@@ -45,6 +45,8 @@ export default async function processPostTypeQuery(
     }
   }
 
+  // console.log('preview', preview)
+
   // Execute query.
   response.post = await apolloClient
     .query({query, variables})

--- a/functions/wordpress/posts/getPostsDateArchive.js
+++ b/functions/wordpress/posts/getPostsDateArchive.js
@@ -58,6 +58,8 @@ export default async function getPostsDateArchive(
     day
   }
 
+  // console.log('jr getPostsDateArchive', variables)
+
   // Conditionally add excluded IDs if provided.
   if (exclude?.length) {
     variables.notIn = exclude

--- a/lib/wordpress/posts/queryCPTById.js
+++ b/lib/wordpress/posts/queryCPTById.js
@@ -1,0 +1,49 @@
+import categoriesPostFields from '@/lib/wordpress/_query-partials/categoriesPostFields'
+import commentsPostFields from '@/lib/wordpress/_query-partials/commentsPostFields'
+import defaultPageData from '@/lib/wordpress/_query-partials/defaultPageData'
+import tagsPostFields from '@/lib/wordpress/_query-partials/tagsPostFields'
+import {gql} from '@apollo/client'
+
+// Query: retrieve post by specified identifier.
+
+/**
+ * @param  postType
+ */
+export default function constructCPTQuery(postType) {
+  const queryCPTById = gql`
+  query CPT_QUERY($id: ID!) {
+    ${defaultPageData}
+    ${postType}(id: $id, idType: DATABASE_ID) {
+      blocksJSON
+      databaseId
+      date
+      slug
+      uri
+      title
+      status
+      featuredImage {
+        node {
+          altText
+          sourceUrl
+          databaseId
+          parentId
+        }
+      }
+      seo {
+        breadcrumbs {
+          text
+          url
+        }
+        fullHead
+        metaRobotsNofollow
+        metaRobotsNoindex
+        title
+      }
+    }
+    ${tagsPostFields}
+    ${categoriesPostFields}
+    ${commentsPostFields}
+  }
+`
+  return queryCPTById
+}


### PR DESCRIPTION
Closes #931 

### Description
CPT Previews were nto being assigned due to missing logic in building the Apollo Query. 
- Added a dynamic function to query for CPT based on variable names
- Moved Previews to it's own route, soa s not to use the query by year feature as a fallback.

### Verification

How will a stakeholder test this?

1. `git checkout 
2.
3.
