### PR TITLE
Fix prettier conflict with VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
   // This will get emmet working in JSX.
   "emmet.includeLanguages": {
     "javascript": "javascriptreact"
-  }
+  },
+  "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false
 }


### PR DESCRIPTION
Closes https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/979

### Description

Prettier's `bracketSpacing: false,` rule is overruled via VS Code's default `"javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": true` which results in not removing the bracket spacing from import statements.

### Screenshot
**Before**
![before](https://user-images.githubusercontent.com/48773133/160246779-3d1c870b-0254-41a8-a1ef-0257a5820640.gif)

**Before**
![after](https://user-images.githubusercontent.com/48773133/160246782-0e739f21-35b8-4b55-8860-106b0886058c.gif)

### Verification

How will a stakeholder test this?

1. disable personal VS Code settings
2. open any Javascript file that has import statements
3. save the file
